### PR TITLE
feat(autoupdate): first-party auto-update plugin with release/dev channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude/
 /nistru
+/bin/
 cmd/nistru/nistru
 /examples/plugins/hello-world/hello-world
 /examples/plugins/gofmt/gofmt-plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- First-party `autoupdate` plugin: watches GitHub Releases for new versions, shows an update-available badge in the status bar, and ships palette commands to install, roll back, switch channel (release/dev), check now, and view release notes.
+- Plugin host primitives for in-process async notifications: `plugin.HostAware` interface and `Host.PostNotif(plugin, method, params)` non-blocking notification pump.
+- `nistru -version` flag that prints the running version.
+- Makefile `build` target with `-ldflags -X main.Version=$(git describe ...)` for reproducible version embedding.
+
 ### Changed
 
 - Reorganize repo to modern Go layout: editor core moves to `internal/editor/`, binary entry point to `cmd/nistru/`, first-party plugins to `internal/plugins/`. Public packages (`plugin/`, `sdk/plugsdk/`) unchanged.
+
+### Security
+
+- Auto-update installation is never automatic: palette invocation of `autoupdate:install` is the only path to a binary swap. The scheduled checker only updates the status bar.
 
 ### Breaking
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: test test-short race cover lint fuzz e2e ci fmt clean examples-test
+.PHONY: test test-short race cover lint fuzz e2e ci fmt clean examples-test build
+
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+
+build:
+	go build -ldflags "-X main.Version=$(VERSION)" -o bin/nistru ./cmd/nistru
 
 test:
 	go test ./...
@@ -45,3 +50,4 @@ fmt:
 
 clean:
 	rm -f coverage.out coverage.html
+	rm -rf bin

--- a/README.md
+++ b/README.md
@@ -99,6 +99,38 @@ The editor is modal. It opens in **Normal** mode (cursor navigation). Press `i`,
 
 Autosave is enabled by default. After any buffer change, a 250 ms idle debounce schedules a write; rapid typing produces exactly one write when typing stops. Writes are atomic (write to `<path>.tmp`, then rename over the original), so a killed process never leaves a half-written file. The right side of the status bar shows `● unsaved` while dirty and `✓ saved` for about a second after each flush. A size guard refuses to open files larger than 1 MiB, and binary files are refused if a NUL byte appears in the first 512 bytes.
 
+## Auto-update
+
+Nistru ships with a first-party `autoupdate` plugin that watches GitHub Releases for newer versions. It is enabled by default, runs quietly in the background, and never swaps the binary without explicit palette invocation.
+
+**What it does.** Once an hour, the plugin issues a single unauthenticated `GET` to `api.github.com/repos/savimcio/nistru/releases`. If a newer version is available, a status-bar segment announces it; palette commands let you install it, roll back, switch channels, or view release notes. No telemetry is collected and no data is sent outbound beyond the GitHub API request itself.
+
+**Channels.**
+
+| Channel | Tracks |
+|---|---|
+| `release` (default) | stable GitHub releases only |
+| `dev` | includes prereleases |
+
+Switch with the `autoupdate:switch-channel` palette command, or start on a specific channel via `NISTRU_AUTOUPDATE_CHANNEL=dev`.
+
+**Environment variables.**
+
+| Variable | Effect |
+|---|---|
+| `NISTRU_AUTOUPDATE_DISABLE=1` | disables the plugin entirely |
+| `NISTRU_AUTOUPDATE_INTERVAL=30m` | custom check interval (any Go `time.ParseDuration` value) |
+| `NISTRU_AUTOUPDATE_CHANNEL=release\|dev` | start on a specific channel |
+| `NISTRU_AUTOUPDATE_REPO=owner/repo` | override source repository (useful for forks) |
+
+**Installing an update.** Open the palette with `Ctrl+P` and run `autoupdate:install`. On Linux and macOS, the new binary is downloaded, its SHA-256 is verified against the release's `checksums.txt`, and it is atomically swapped in place (the previous binary is retained for the session as `nistru.prev`). Restart nistru (`Ctrl+Q`, then relaunch) to pick up the new version. On Windows, the plugin does **not** swap the binary; it prints the appropriate `go install` command and leaves installation to you.
+
+**Rolling back.** `Ctrl+P` → `autoupdate:rollback` restores the previous binary from `nistru.prev`. The rollback target is retained only for the current session, so restart nistru before relying on it.
+
+**Prerequisites for in-place installation.** The target release must publish artifacts for your `GOOS/GOARCH` alongside a `checksums.txt` file. If your copy of nistru was installed via `go install ...@latest` and no matching release artifact exists, the plugin falls back to notifying you with the correct `go install` command instead of attempting a swap.
+
+**Privacy.** One unauthenticated request per hour to GitHub's public Releases API. GitHub observes the requester's IP address (as it would for any HTTP client). No identifying information, crash data, or editor state is disclosed. To opt out entirely, set `NISTRU_AUTOUPDATE_DISABLE=1`.
+
 ## Plugins
 
 Nistru has a plugin system with two transports (in-process Go for panes, out-of-process JSON-RPC for everything else). The bundled file tree is itself a plugin. See **[docs/plugins.md](docs/plugins.md)** for the architecture, manifest schema, SDK, and worked examples.

--- a/cmd/nistru/main.go
+++ b/cmd/nistru/main.go
@@ -8,11 +8,27 @@ import (
 	"os"
 
 	"github.com/savimcio/nistru/internal/editor"
+	"github.com/savimcio/nistru/internal/plugins/autoupdate"
 )
+
+// Version is the build version. Defaults to "dev"; override via
+// -ldflags "-X main.Version=..." at build time. The autoupdate plugin
+// reads this via SetVersion so a ldflags-stamped local build and the
+// update checker agree on what "current" means.
+var Version = "dev"
 
 func main() {
 	path := flag.String("path", ".", "root directory for the file tree")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+	if *showVersion {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
+	// Pass the ldflags-stamped Version to the autoupdate plugin *before*
+	// the editor starts. The plugin treats "dev" as "not injected" and
+	// falls back to ReadBuildInfo for `go install @tag` installs.
+	autoupdate.SetVersion(Version)
 	if err := editor.Run(*path); err != nil {
 		fmt.Fprintf(os.Stderr, "nistru: %v\n", err)
 		os.Exit(1)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -178,6 +178,65 @@ registry.RegisterInProc(myplugin.New(root))
 
 See `internal/plugins/treepane/treepane.go` for a full example.
 
+### In-process async notifications
+
+In-process plugins run `OnEvent` on the Bubble Tea goroutine and must return quickly. When work needs to happen in the background — polling a file, watching a socket, running a ticker — spawn a goroutine and report results back to the host via `plugin.Host.PostNotif`.
+
+Opt in by implementing the optional `HostAware` interface. The host calls `SetHost` once, before `Initialize` is dispatched:
+
+```go
+type HostAware interface {
+    SetHost(h *plugin.Host)
+}
+```
+
+`PostNotif` synthesizes a JSON-RPC notification and routes it through the same inbound pipeline that out-of-process plugins use, so the editor model handles it identically regardless of transport:
+
+```go
+func (h *plugin.Host) PostNotif(plugin, method string, params any) error
+```
+
+It's **safe to call from any goroutine** and **non-blocking**: if the inbound buffer is saturated the notification is dropped and an error is returned. Host-side bookkeeping for methods like `commands/register` runs synchronously before the send, so command registration is effective on return even when the send itself drops. Supported methods mirror the wire protocol: `statusBar/set`, `ui/notify`, `commands/register`, `commands/unregister`.
+
+Use it for status-bar updates, toast notifications, and late command registration. Do not call it from an out-of-process plugin — those already have a dedicated writer goroutine.
+
+```go
+type clock struct {
+    host *plugin.Host
+    stop chan struct{}
+}
+
+func (c *clock) Name() string         { return "clock" }
+func (c *clock) Activation() []string { return []string{"onStart"} }
+func (c *clock) SetHost(h *plugin.Host) { c.host = h }
+
+func (c *clock) OnEvent(ev any) []plugin.Effect {
+    if _, ok := ev.(plugin.Initialize); ok {
+        c.stop = make(chan struct{})
+        go c.tick()
+    }
+    return nil
+}
+
+func (c *clock) tick() {
+    t := time.NewTicker(time.Second)
+    defer t.Stop()
+    for {
+        select {
+        case <-c.stop:
+            return
+        case now := <-t.C:
+            _ = c.host.PostNotif("clock", "statusBar/set", map[string]any{
+                "segment": "clock",
+                "text":    now.Format("15:04:05"),
+            })
+        }
+    }
+}
+
+func (c *clock) Shutdown() error { close(c.stop); return nil }
+```
+
 ## Effects
 
 In-process plugin calls return effects; out-of-process plugins send equivalent JSON-RPC notifications. Both flow through the same host plumbing:
@@ -300,6 +359,68 @@ func (p *fmt) OnExecuteCommand(id string, _ json.RawMessage) (any, error) {
 
 The bundled [`gofmt` example](../examples/plugins/gofmt/main.go) currently calls `BufferEdit` synchronously and is vulnerable to this pattern. Its tests work around it by invoking `ExecuteCommand` in a goroutine and asserting against `h.Requests()`. A follow-up should either dispatch handlers on a per-frame goroutine inside the SDK or rewrite the example to spawn.
 
+## Auto-update (first-party example)
+
+The bundled `autoupdate` plugin (under `internal/plugins/autoupdate/`) is the canonical template for any in-process plugin that needs to do work on a schedule. Read it before writing your own background plugin — it exercises every piece of the `HostAware` + `PostNotif` contract end-to-end: a ticker-driven poll loop, a status-bar segment, late palette-command registration, and a `ui/notify` toast when a new release appears.
+
+**Why this pattern exists.** In-process plugins receive events synchronously on the Bubble Tea goroutine. `OnEvent` must return quickly or it will stall the editor's `Update` loop. Anything long-running — an HTTP request, a file watcher, a timer — has to run on its own goroutine. But background goroutines can't safely touch the model directly; they need a way to push changes back through the same pipeline that delivers out-of-process plugin notifications.
+
+That's what `HostAware` + `PostNotif` provide. Implement `SetHost` to capture the host reference, spawn a goroutine from your `Initialize` handler, and call `host.PostNotif` whenever the goroutine has something to report. Under the hood the host synthesizes a JSON-RPC notification and routes it through the same inbound channel used by external plugins, so the editor model's `handlePluginNotif` treats both transports identically.
+
+### Minimal template
+
+```go
+type MyPlugin struct {
+    host *plugin.Host
+}
+
+func (p *MyPlugin) Name() string         { return "myplugin" }
+func (p *MyPlugin) Activation() []string { return []string{"onStart"} }
+func (p *MyPlugin) Shutdown() error      { return nil }
+
+func (p *MyPlugin) SetHost(h *plugin.Host) { p.host = h }
+
+func (p *MyPlugin) OnEvent(event any) []plugin.Effect {
+    if _, ok := event.(plugin.Initialize); ok {
+        go p.backgroundLoop()
+    }
+    return nil
+}
+
+func (p *MyPlugin) backgroundLoop() {
+    tick := time.NewTicker(1 * time.Minute)
+    defer tick.Stop()
+    for range tick.C {
+        _ = p.host.PostNotif("myplugin", "statusBar/set", map[string]string{
+            "segment": "status",
+            "text":    "updated " + time.Now().Format(time.Kitchen),
+            "color":   "cyan",
+        })
+    }
+}
+```
+
+The real `autoupdate` plugin (`internal/plugins/autoupdate/`) fleshes this shape out with a channel-driven stop signal, configurable interval, HTTP client with retry/backoff, SHA-256 verification, and late palette-command registration on first successful poll. It's the recommended reference for any plugin whose work should survive a `Shutdown` cleanly.
+
+### `PostNotif` contract
+
+- **Safe to call from any goroutine.** Internally guarded; you do not need to hold a lock.
+- **Non-blocking.** If the inbound buffer is saturated the notification is dropped and a non-nil error is returned. Do not retry in a tight loop; drop-on-full is the intended backpressure.
+- **Host-side bookkeeping is synchronous.** For methods like `commands/register` / `commands/unregister`, the host updates its command table before the send returns, so a subsequent palette open reflects the change even if the actual notification frame was dropped.
+- **Supported methods today** (see `internal/editor/model.go` `handlePluginNotif`):
+
+  | Method | Effect |
+  |---|---|
+  | `statusBar/set` | upsert a status-bar segment (`{segment, text, color}`) |
+  | `ui/notify` | transient toast in the status area (`{level, message}`) |
+  | `commands/register` | add a palette entry (`{id, title}`) |
+  | `commands/unregister` | remove a palette entry (`{id}`) |
+  | `pane/invalidate` | request a re-render of your pane |
+
+  Any other method name is ignored by the model; check `handlePluginNotif` before shipping a new verb.
+
+Use `PostNotif` only from in-process plugins. Out-of-process plugins already have a dedicated writer goroutine and should emit notifications via `plugsdk.Client` instead.
+
 ## Reference
 
 - Host internals: `plugin/host.go`, `plugin/extproc.go`
@@ -308,3 +429,4 @@ The bundled [`gofmt` example](../examples/plugins/gofmt/main.go) currently calls
 - SDK: `sdk/plugsdk/plugsdk.go`
 - Plugin-author harness: `sdk/plugsdk/plugintest/plugintest.go`
 - Examples: `examples/plugins/{hello-world,gofmt}/`
+- First-party async plugin: `internal/plugins/autoupdate/`

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20260420102150-fe550f2efce5
 	github.com/kujtimiihoxha/vimtea v0.0.2
+	golang.org/x/mod v0.31.0
 	honnef.co/go/tools v0.7.0
 )
 
@@ -36,7 +37,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
-	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/internal/editor/autoupdate_integration_test.go
+++ b/internal/editor/autoupdate_integration_test.go
@@ -1,0 +1,307 @@
+package editor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/savimcio/nistru/internal/plugins/autoupdate"
+	"github.com/savimcio/nistru/internal/plugins/treepane"
+	"github.com/savimcio/nistru/plugin"
+)
+
+// rewriteAPITransport forwards every request targeting api.github.com to the
+// test server. Non-matching hosts fall through to the base transport, but in
+// practice the autoupdate plugin only calls api.github.com so the fallthrough
+// is defensive. Mirrors the pattern in internal/plugins/autoupdate/github_test.go
+// but scoped to the api host so an accidentally-real request still fails fast.
+type rewriteAPITransport struct {
+	base  http.RoundTripper
+	toURL string
+}
+
+func (t rewriteAPITransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	u, err := clone.URL.Parse(t.toURL)
+	if err != nil {
+		return nil, err
+	}
+	clone.URL.Scheme = u.Scheme
+	clone.URL.Host = u.Host
+	clone.Host = u.Host
+	return t.base.RoundTrip(clone)
+}
+
+// TestAutoupdatePluginEndToEnd exercises the full pipe from the autoupdate
+// plugin's background checker through Host.PostNotif, Host.inbound,
+// Host.Recv(), Model.Update, handlePluginNotif, and finally into
+// m.statusSegments. Component-level coverage for each hop already exists
+// (autoupdate tests for the checker, plugin/host_test.go for PostNotif, and
+// model_component_test.go for statusBar/set); this test closes the gap
+// between the plugin and the editor model with a single end-to-end run.
+func TestAutoupdatePluginEndToEnd(t *testing.T) {
+	// Clear any env-var overrides that New() honours. The test construction
+	// options win regardless (they apply after env), but clearing keeps the
+	// test hermetic under CI where the host may have these set.
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "")
+	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "")
+
+	// Workspace root with a couple of files so treepane has something real
+	// to index. The contents do not matter; we never open them.
+	root := t.TempDir()
+	writeFile(t, root, "a.txt", "hello\n")
+	writeFile(t, root, "b.go", "package main\n")
+
+	// httptest server serving one canned release. The autoupdate checker
+	// issues GET /repos/owner/nistru/releases and decodes a JSON array.
+	const relJSON = `[
+      {"tag_name":"v99.0.0","name":"99.0.0","body":"notes","published_at":"2099-01-01T00:00:00Z","prerelease":false,"draft":false}
+    ]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(relJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	// Goroutine baseline AFTER httptest.Server spins up but BEFORE the host
+	// and checker start. Taken here so the final settle-check is comparing
+	// like for like: both counts include the httptest listener goroutine.
+	baseGoroutines := runtime.NumGoroutine()
+
+	// Build a fresh registry that mirrors NewModel's but substitutes a
+	// test-configured autoupdate plugin.
+	registry := plugin.NewRegistry()
+	tp, err := treepane.New(root)
+	if err != nil {
+		t.Fatalf("treepane.New: %v", err)
+	}
+	registry.RegisterInProc(tp)
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	// Dedicated transport per test so we can call CloseIdleConnections() on
+	// shutdown without side-effecting http.DefaultTransport. Disabling
+	// keep-alives guarantees the RoundTrip goroutines drain immediately
+	// rather than hanging around in the connection pool.
+	innerTransport := &http.Transport{
+		DisableKeepAlives: true,
+	}
+	t.Cleanup(innerTransport.CloseIdleConnections)
+	au := autoupdate.New(
+		autoupdate.WithRepo("owner/nistru"),
+		autoupdate.WithHTTPClient(&http.Client{
+			Timeout:   5 * time.Second,
+			Transport: rewriteAPITransport{base: innerTransport, toURL: srv.URL},
+		}),
+		autoupdate.WithInterval(10*time.Millisecond),
+		autoupdate.WithStatePath(statePath),
+		autoupdate.WithInstaller(noopInstallerForTest{}),
+		// Pin the detected current version so the comparison is
+		// deterministic regardless of how `go test` was invoked. An "unknown"
+		// current would also work (it sorts behind any real version), but
+		// pinning is unambiguous.
+		autoupdate.WithCurrent("v0.0.1"),
+	)
+	registry.RegisterInProc(au)
+
+	m, err := newModelWithRegistry(root, registry)
+	if err != nil {
+		t.Fatalf("newModelWithRegistry: %v", err)
+	}
+
+	// Prime the host.Recv pump. Init returns tea.Batch(editor.Init,
+	// host.Recv); we don't care about the editor init cmd here, but we DO
+	// need to keep calling host.Recv() to drain PluginNotifMsg frames.
+	//
+	// newModelWithRegistry now emits Initialize internally so in-proc plugins
+	// that activate on onStart (autoupdate, treepane) have their OnEvent
+	// handlers invoked before we return. The checker goroutine is already
+	// running by this point; we just need to drain its status-bar frames.
+	_ = m.Init()
+
+	// Pump the model's inbound chain. A single helper goroutine pulls
+	// frames from host.Recv() and feeds them to the main goroutine over
+	// msgCh. The main goroutine runs Update and checks for the target
+	// segment. Using a single pump avoids the "one stuck Recv goroutine
+	// per timeout iteration" leak pattern that a per-iteration helper
+	// goroutine would accumulate (host.inbound is never closed, so a
+	// blocked Recv cannot be cancelled from the outside).
+	//
+	// We capture host into a local so the pump goroutine does not race
+	// with the main goroutine's reassignment of m. The host pointer
+	// itself is immutable post-construction.
+	host := m.host
+	msgCh := make(chan tea.Msg, 64)
+	pumpStop := make(chan struct{})
+	pumpDone := make(chan struct{})
+	go func() {
+		defer close(pumpDone)
+		for {
+			recv := host.Recv()
+			if recv == nil {
+				return
+			}
+			msg := recv()
+			if msg == nil {
+				return
+			}
+			select {
+			case msgCh <- msg:
+			case <-pumpStop:
+				return
+			}
+		}
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	seenMethods := []string{}
+	found := false
+loop:
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		select {
+		case msg := <-msgCh:
+			if nm, isNotif := msg.(plugin.PluginNotifMsg); isNotif {
+				seenMethods = append(seenMethods, nm.Plugin+":"+nm.Method)
+			}
+			newM, _ := m.Update(msg)
+			m = newM.(*Model)
+
+			for _, seg := range m.statusSegments {
+				if seg.Plugin == "autoupdate" && seg.Name == "autoupdate" &&
+					strings.Contains(seg.Text, "v99.0.0") && seg.Color == "green" {
+					found = true
+					break
+				}
+			}
+			if found {
+				break loop
+			}
+		case <-time.After(remaining):
+			break loop
+		}
+	}
+
+	if !found {
+		t.Fatalf("did not observe autoupdate statusBar segment within 2s.\n"+
+			"  statusSegments=%+v\n  seen notifications=%v",
+			m.statusSegments, seenMethods)
+	}
+
+	// Confirm exactly one autoupdate segment with the expected shape.
+	var auSegs []statusSegment
+	for _, s := range m.statusSegments {
+		if s.Plugin == "autoupdate" {
+			auSegs = append(auSegs, s)
+		}
+	}
+	if len(auSegs) != 1 {
+		t.Fatalf("want exactly 1 autoupdate segment, got %d: %+v", len(auSegs), auSegs)
+	}
+	got := auSegs[0]
+	if got.Name != "autoupdate" {
+		t.Errorf("segment Name: got %q, want %q", got.Name, "autoupdate")
+	}
+	if got.Color != "green" {
+		t.Errorf("segment Color: got %q, want %q", got.Color, "green")
+	}
+	if !strings.Contains(got.Text, "v99.0.0") {
+		t.Errorf("segment Text: got %q, want substring v99.0.0", got.Text)
+	}
+
+	// Clean shutdown. Any goroutine leak surfaces below.
+	if err := m.host.Shutdown(500 * time.Millisecond); err != nil {
+		t.Errorf("host.Shutdown: %v", err)
+	}
+
+	// Drain the pump goroutine. After Shutdown no more PostNotif fires,
+	// and host.inbound is never closed — so the pump may be blocked on
+	// recv() OR on msgCh<-. Signal stop first (to unblock the send side),
+	// then repeatedly PostNotif a sentinel (one per pending inbound frame)
+	// so the pump's recv() unblocks and finds pumpStop closed on the next
+	// select. We re-post defensively because the inbound buffer may have
+	// been saturated by the checker's final burst, dropping earlier
+	// sentinels silently per PostNotif's non-blocking contract.
+	close(pumpStop)
+	drainDeadline := time.Now().Add(1 * time.Second)
+	for {
+		select {
+		case <-msgCh:
+			// discard
+		case <-pumpDone:
+			goto drained
+		case <-time.After(20 * time.Millisecond):
+			// Either the pump is blocked on recv() with no pending
+			// frames (sentinel was dropped), or the pump is blocked on
+			// msgCh<- but msgCh is empty right now. Re-post a sentinel
+			// and loop. The close(pumpStop) above guarantees the pump
+			// returns on its next select pass, so this is bounded.
+			if time.Now().After(drainDeadline) {
+				t.Errorf("pump goroutine did not exit within 1s after sentinel")
+				goto drained
+			}
+			_ = host.PostNotif("test-sentinel", "noop", nil)
+		}
+	}
+drained:
+
+	// Close idle connections on our dedicated transport before taking the
+	// final goroutine snapshot — http.Transport keeps connection-pool
+	// reapers alive for ~90s by default otherwise.
+	innerTransport.CloseIdleConnections()
+
+	// Give the runtime a brief window for stopped goroutines to be reaped.
+	// Tolerance of 2 accounts for stdlib noise (scheduler goroutines that
+	// transiently appear and disappear during the settle window).
+	if !waitGoroutinesSettled(baseGoroutines+2, 500*time.Millisecond) {
+		t.Errorf("goroutine leak: before=%d, after=%d",
+			baseGoroutines, runtime.NumGoroutine())
+	}
+}
+
+// waitGoroutinesSettled polls runtime.NumGoroutine() until it is <= upper
+// or the deadline expires. Returns true on settle, false on timeout.
+func waitGoroutinesSettled(upper int, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= upper {
+			return true
+		}
+		// Short yield; we must avoid bare time.Sleep per house rules, but
+		// a tight polling loop with a deadline is acceptable and mirrors
+		// the pattern already used by waitUntil in other component tests.
+		time.Sleep(10 * time.Millisecond)
+	}
+	return runtime.NumGoroutine() <= upper
+}
+
+// noopInstallerForTest mirrors autoupdate's noopInstaller but is declared
+// locally so the test does not depend on that type being exported. The
+// autoupdate plugin only needs Install/Rollback to satisfy the Installer
+// interface; neither is invoked under this test because we never dispatch
+// an autoupdate:install command.
+type noopInstallerForTest struct{}
+
+func (noopInstallerForTest) Install(_ context.Context, _ *plugin.Host, _ autoupdate.Release, _ string) error {
+	return nil
+}
+
+func (noopInstallerForTest) Rollback(_ context.Context, _ *plugin.Host) error {
+	return nil
+}
+
+// Compile-time assertion so a drift in the Installer interface surfaces at
+// build time rather than as a mysterious runtime behaviour.
+var _ autoupdate.Installer = noopInstallerForTest{}

--- a/internal/editor/model.go
+++ b/internal/editor/model.go
@@ -13,8 +13,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/kujtimiihoxha/vimtea"
 
-	"github.com/savimcio/nistru/plugin"
+	"github.com/savimcio/nistru/internal/plugins/autoupdate"
 	"github.com/savimcio/nistru/internal/plugins/treepane"
+	"github.com/savimcio/nistru/plugin"
 )
 
 // App-level key constants. Inlining these rather than splitting into keys.go
@@ -116,10 +117,30 @@ func NewModel(root string) (*Model, error) {
 	}
 	registry.RegisterInProc(tp)
 
+	registry.RegisterInProc(autoupdate.New())
+
+	return newModelWithRegistry(root, registry)
+}
+
+// newModelWithRegistry is the shared constructor used by NewModel and by
+// tests that need to inject a pre-populated registry (e.g. a replacement
+// autoupdate plugin with test seams). It starts the host, fires the
+// onStart-matching Initialize event (so in-proc plugins register their
+// palette commands, start background workers, etc.), then snapshots commands
+// and returns a Model ready for Init().
+//
+// Emit(Initialize) runs OnEvent synchronously for in-proc plugins on the
+// calling goroutine; side effects (commands/register, statusBar/set) flow
+// through PostNotif whose host-side bookkeeping runs before the inbound
+// channel send, so the subsequent host.Commands() snapshot already includes
+// anything a plugin registered during Initialize.
+func newModelWithRegistry(root string, registry *plugin.Registry) (*Model, error) {
 	host := plugin.NewHost(registry)
 	if err := host.Start(root); err != nil {
 		return nil, fmt.Errorf("start plugin host: %w", err)
 	}
+
+	host.Emit(plugin.Initialize{RootPath: root, Capabilities: nil})
 
 	m := &Model{
 		root:     root,

--- a/internal/editor/model_component_test.go
+++ b/internal/editor/model_component_test.go
@@ -26,6 +26,16 @@ import (
 
 func newTestModel(t *testing.T, root string) *Model {
 	t.Helper()
+	// NewModel now emits Initialize at boot, which spins up the autoupdate
+	// plugin's background checker and pokes the real user config dir for
+	// persistent state. Neither belongs in component tests; disable via env.
+	// The DISABLE knob skips the checker goroutine while still registering
+	// palette commands (see autoupdate.handleInitialize), so any command-
+	// registry behavior exercised here still works.
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "1")
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "")
+	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "")
 	m, err := NewModel(root)
 	if err != nil {
 		t.Fatalf("NewModel(%q): %v", root, err)

--- a/internal/editor/model_e2e_test.go
+++ b/internal/editor/model_e2e_test.go
@@ -156,11 +156,30 @@ func assertGolden(t *testing.T, name string, got []byte) {
 // in the status bar — absolute paths would leak the tempdir name into the
 // golden).
 
+// disableAutoupdate sets the full set of autoupdate env overrides so the
+// plugin is fully hermetic: background checker off, no ambient repo/channel/
+// interval leaking in from the developer shell. Every e2e test that goes
+// through NewModel calls this so Initialize-at-boot doesn't introduce
+// network-flakiness or golden drift.
+func disableAutoupdate(t *testing.T) {
+	t.Helper()
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "1")
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "")
+	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "")
+}
+
 // newRenderedModel constructs a Model at (w,h), applies setup, and returns the
 // rendered View(). The root argument controls which workspace the tree pane
 // is rooted at.
 func newRenderedModel(t *testing.T, root string, w, h int, setup func(*Model)) string {
 	t.Helper()
+	// Disable the autoupdate background checker for every golden-capturing
+	// test. NewModel fires Initialize at boot, which would otherwise spin up
+	// a goroutine that hits api.github.com and (on first response) writes a
+	// green "v…" segment into the status bar — the resulting non-determinism
+	// drifts every goldens in this file.
+	disableAutoupdate(t)
 	m, err := NewModel(root)
 	if err != nil {
 		t.Fatalf("NewModel(%q): %v", root, err)
@@ -371,6 +390,7 @@ func TestE2E_EditAutosaveToDisk(t *testing.T) {
 	// real tea.Program. Uses Ctrl+S (force save) rather than waiting out the
 	// 250 ms autosave debounce so the test stays inside the <200 ms budget.
 	// A separate -short-skipping test below covers the true debounce path.
+	disableAutoupdate(t)
 	dir := t.TempDir()
 	path := writeFile(t, dir, "note.txt", "seed\n")
 	m, err := NewModel(dir)
@@ -433,6 +453,7 @@ func TestE2E_EditAutosaveToDisk(t *testing.T) {
 func TestE2E_PaletteRegisteredCommandExecutes(t *testing.T) {
 	// Register an in-proc test plugin that captures ExecuteCommand events.
 	// We construct the Host ourselves so we can inject the test plugin.
+	disableAutoupdate(t)
 	root := emptyRoot(t)
 	m, err := NewModel(root)
 	if err != nil {
@@ -468,6 +489,7 @@ func TestE2E_CtrlCInInsertModeStaysAsCopyAndReturnsToNormal(t *testing.T) {
 	// synthVimMotion, which prepends SetMode(ModeNormal). We drive that flow
 	// through a real tea.Program to confirm the buffer isn't quit and the
 	// editor ends in Normal mode.
+	disableAutoupdate(t)
 	dir := t.TempDir()
 	path := writeFile(t, dir, "z.txt", "line1\nline2\n")
 	m, err := NewModel(dir)
@@ -517,6 +539,7 @@ func TestE2E_CtrlQWithDirtyBufferFlushesBeforeExit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("flush-on-quit is synchronous but setup drives real tea.Program; skipped under -short")
 	}
+	disableAutoupdate(t)
 	dir := t.TempDir()
 	path := writeFile(t, dir, "q.txt", "seed\n")
 	m, err := NewModel(dir)

--- a/internal/editor/model_init_test.go
+++ b/internal/editor/model_init_test.go
@@ -1,0 +1,78 @@
+package editor
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNewModelEmitsInitializeAndRegistersAutoupdateCommands is the regression
+// guard for the "NewModel never emitted Initialize in production" bug: the
+// editor core constructed the plugin host and Start()ed it, but nothing fired
+// an onStart-matching event, so in-proc plugins that register palette commands
+// during Initialize (like autoupdate) never saw the handler run. The bug hid
+// for weeks because every existing test manually called
+// host.Emit(plugin.Initialize{...}) after construction, masking the gap.
+//
+// The assertion below constructs a production Model via NewModel and checks
+// that autoupdate's five palette commands landed on m.commands. Without the
+// Emit(Initialize) call in newModelWithRegistry, this test fails with an empty
+// commands map.
+//
+// NISTRU_AUTOUPDATE_DISABLE=1 is set so the background checker goroutine and
+// the real GitHub poll don't fire during the test — command registration
+// happens before the disable short-circuit (see autoupdate.handleInitialize)
+// so this does NOT mask the bug we're guarding against.
+func TestNewModelEmitsInitializeAndRegistersAutoupdateCommands(t *testing.T) {
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "1")
+	// Clear any ambient overrides from the developer shell so the test is
+	// hermetic. The DISABLE above is the only knob we want active.
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "")
+	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "")
+
+	root := t.TempDir()
+
+	m, err := NewModel(root)
+	if err != nil {
+		t.Fatalf("NewModel(%q): %v", root, err)
+	}
+	t.Cleanup(func() { _ = m.host.Shutdown(100 * time.Millisecond) })
+
+	wantIDs := []string{
+		"autoupdate:check",
+		"autoupdate:install",
+		"autoupdate:rollback",
+		"autoupdate:switch-channel",
+		"autoupdate:release-notes",
+	}
+	for _, id := range wantIDs {
+		ref, ok := m.commands[id]
+		if !ok {
+			t.Errorf("m.commands missing %q; got keys: %v", id, keysOf(m.commands))
+			continue
+		}
+		if ref.Plugin != "autoupdate" {
+			t.Errorf("command %q: Plugin=%q, want %q", id, ref.Plugin, "autoupdate")
+		}
+	}
+
+	// Spot-check a non-empty Title on at least one entry — an earlier failure
+	// mode had commands register with empty titles, which broke palette fuzzy
+	// matching. `autoupdate:check` is the canonical smoke-test target.
+	if ref, ok := m.commands["autoupdate:check"]; ok {
+		if ref.Title == "" {
+			t.Errorf("autoupdate:check has empty Title; want non-empty")
+		}
+	}
+}
+
+// keysOf returns a slice of keys from m for failure-message pretty-printing.
+// Order is not stable (Go map iteration) but the test only uses it inside
+// t.Errorf, so readability > determinism.
+func keysOf[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/plugins/autoupdate/asset.go
+++ b/internal/plugins/autoupdate/asset.go
@@ -1,0 +1,129 @@
+package autoupdate
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrNoAssetForPlatform is returned by AssetMatch when none of the known
+// release-asset naming conventions matches the running platform. Callers
+// (typically Preflight) surface this to the user as a signal to fall back
+// to `go install`.
+var ErrNoAssetForPlatform = errors.New("autoupdate: no release assets for this platform")
+
+// checksumsAssetName is the exact (case-insensitive) filename goreleaser
+// emits for a checksum manifest.
+const checksumsAssetName = "checksums.txt"
+
+// AssetMatch picks the best binary asset in rel for the supplied goos /
+// goarch and also returns the accompanying checksums manifest if present.
+//
+// Supported name patterns (tried in order, case-insensitive):
+//
+//	nistru_<version>_<goos>_<goarch>.tar.gz
+//	nistru_<goos>_<goarch>.tar.gz
+//	nistru-<goos>-<goarch>.tar.gz
+//	nistru_<version>_<goos>_<goarch>.zip
+//	nistru_<goos>_<goarch>.zip
+//	nistru-<goos>-<goarch>.zip
+//
+// The version token is not compared — we only care that the os+arch pair is
+// present. Returns the matched binary asset, the checksums asset (zero value
+// if none), or an error (ErrNoAssetForPlatform if nothing matches).
+func AssetMatch(rel Release, goos, goarch string) (Asset, Asset, error) {
+	var (
+		binary    Asset
+		checksums Asset
+		found     bool
+	)
+
+	goos = strings.ToLower(goos)
+	goarch = strings.ToLower(goarch)
+
+	for _, a := range rel.Assets {
+		lower := strings.ToLower(a.Name)
+		if lower == checksumsAssetName {
+			checksums = a
+			continue
+		}
+		if found {
+			continue
+		}
+		if assetNameMatches(lower, goos, goarch) {
+			binary = a
+			found = true
+		}
+	}
+
+	if !found {
+		return Asset{}, Asset{}, ErrNoAssetForPlatform
+	}
+	return binary, checksums, nil
+}
+
+// assetNameMatches returns true if name (already lowercased) matches any of
+// the supported goreleaser naming conventions for the given goos/goarch.
+//
+// The allowed extensions are ".tar.gz" (and its ".tgz" alias) for POSIX and
+// ".zip" for Windows. Separators between project/os/arch may be underscores
+// or hyphens; a middle version segment is tolerated but not required.
+func assetNameMatches(name, goos, goarch string) bool {
+	ext := assetExt(name)
+	if ext == "" {
+		return false
+	}
+	stem := strings.TrimSuffix(name, ext)
+
+	// Project prefix: "nistru", followed by either "_" or "-".
+	const project = "nistru"
+	if !strings.HasPrefix(stem, project+"_") && !strings.HasPrefix(stem, project+"-") {
+		return false
+	}
+	rest := stem[len(project)+1:]
+
+	// Split on either separator; the resulting tokens must contain both
+	// goos and goarch as adjacent tokens, in order. We accept one leading
+	// version token (e.g. "v0.2.0" or "0.2.0") or none.
+	tokens := splitOnSepChars(rest, "_-")
+	switch len(tokens) {
+	case 2:
+		return tokens[0] == goos && tokens[1] == goarch
+	case 3:
+		return tokens[1] == goos && tokens[2] == goarch
+	default:
+		return false
+	}
+}
+
+// assetExt returns the archive extension (".tar.gz", ".tgz", ".zip") of
+// name, already lowercased, or "" if none is recognised.
+func assetExt(name string) string {
+	switch {
+	case strings.HasSuffix(name, ".tar.gz"):
+		return ".tar.gz"
+	case strings.HasSuffix(name, ".tgz"):
+		return ".tgz"
+	case strings.HasSuffix(name, ".zip"):
+		return ".zip"
+	default:
+		return ""
+	}
+}
+
+// splitOnSepChars splits s on any byte in seps. Empty tokens are discarded.
+func splitOnSepChars(s, seps string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if strings.IndexByte(seps, s[i]) >= 0 {
+			if i > start {
+				out = append(out, s[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}

--- a/internal/plugins/autoupdate/asset_test.go
+++ b/internal/plugins/autoupdate/asset_test.go
@@ -1,0 +1,143 @@
+package autoupdate
+
+import (
+	"errors"
+	"testing"
+)
+
+// mkAssets is a helper to construct []Asset from a list of names. Sizes and
+// URLs are synthesised deterministically so callers can assert on them.
+func mkAssets(names ...string) []Asset {
+	out := make([]Asset, 0, len(names))
+	for i, n := range names {
+		out = append(out, Asset{
+			Name:               n,
+			BrowserDownloadURL: "https://example.invalid/" + n,
+			Size:               int64(1024 * (i + 1)),
+		})
+	}
+	return out
+}
+
+func TestAssetMatchExact(t *testing.T) {
+	rel := Release{Assets: mkAssets("nistru_v0.2.0_darwin_arm64.tar.gz")}
+	bin, cs, err := AssetMatch(rel, "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("AssetMatch: unexpected err=%v", err)
+	}
+	if bin.Name != "nistru_v0.2.0_darwin_arm64.tar.gz" {
+		t.Fatalf("binary = %q, want exact match", bin.Name)
+	}
+	if cs.Name != "" {
+		t.Fatalf("checksums = %+v, want zero value", cs)
+	}
+}
+
+func TestAssetMatchNoVersion(t *testing.T) {
+	rel := Release{Assets: mkAssets("nistru_linux_amd64.tar.gz")}
+	bin, _, err := AssetMatch(rel, "linux", "amd64")
+	if err != nil {
+		t.Fatalf("AssetMatch: unexpected err=%v", err)
+	}
+	if bin.Name != "nistru_linux_amd64.tar.gz" {
+		t.Fatalf("binary = %q, want no-version match", bin.Name)
+	}
+}
+
+func TestAssetMatchHyphenForm(t *testing.T) {
+	rel := Release{Assets: mkAssets("nistru-darwin-arm64.tar.gz")}
+	bin, _, err := AssetMatch(rel, "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("AssetMatch: unexpected err=%v", err)
+	}
+	if bin.Name != "nistru-darwin-arm64.tar.gz" {
+		t.Fatalf("binary = %q, want hyphen match", bin.Name)
+	}
+}
+
+func TestAssetMatchZip(t *testing.T) {
+	rel := Release{Assets: mkAssets("nistru_v0.2.0_windows_amd64.zip")}
+	bin, _, err := AssetMatch(rel, "windows", "amd64")
+	if err != nil {
+		t.Fatalf("AssetMatch: unexpected err=%v", err)
+	}
+	if bin.Name != "nistru_v0.2.0_windows_amd64.zip" {
+		t.Fatalf("binary = %q, want zip match", bin.Name)
+	}
+}
+
+func TestAssetMatchCaseInsensitive(t *testing.T) {
+	rel := Release{Assets: mkAssets("nistru_Darwin_ARM64.tar.gz")}
+	bin, _, err := AssetMatch(rel, "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("AssetMatch: unexpected err=%v", err)
+	}
+	if bin.Name != "nistru_Darwin_ARM64.tar.gz" {
+		t.Fatalf("binary = %q, want case-insensitive match", bin.Name)
+	}
+}
+
+func TestAssetMatchMissesWrongPlatform(t *testing.T) {
+	rel := Release{Assets: mkAssets("nistru_linux_amd64.tar.gz")}
+	_, _, err := AssetMatch(rel, "darwin", "arm64")
+	if !errors.Is(err, ErrNoAssetForPlatform) {
+		t.Fatalf("AssetMatch err = %v, want ErrNoAssetForPlatform", err)
+	}
+}
+
+func TestAssetMatchPicksChecksums(t *testing.T) {
+	rel := Release{Assets: mkAssets(
+		"nistru_darwin_arm64.tar.gz",
+		"checksums.txt",
+	)}
+	bin, cs, err := AssetMatch(rel, "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("AssetMatch: unexpected err=%v", err)
+	}
+	if bin.Name != "nistru_darwin_arm64.tar.gz" {
+		t.Fatalf("binary = %q", bin.Name)
+	}
+	if cs.Name != "checksums.txt" {
+		t.Fatalf("checksums = %q, want checksums.txt", cs.Name)
+	}
+}
+
+func TestAssetMatchMissingChecksums(t *testing.T) {
+	rel := Release{Assets: mkAssets("nistru_darwin_arm64.tar.gz")}
+	bin, cs, err := AssetMatch(rel, "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("AssetMatch: unexpected err=%v", err)
+	}
+	if bin.Name == "" {
+		t.Fatalf("binary empty")
+	}
+	if cs != (Asset{}) {
+		t.Fatalf("checksums = %+v, want zero value", cs)
+	}
+}
+
+func TestAssetMatchChecksumsCaseInsensitive(t *testing.T) {
+	rel := Release{Assets: mkAssets(
+		"nistru_darwin_arm64.tar.gz",
+		"Checksums.TXT",
+	)}
+	_, cs, err := AssetMatch(rel, "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("AssetMatch: unexpected err=%v", err)
+	}
+	if cs.Name != "Checksums.TXT" {
+		t.Fatalf("checksums = %q", cs.Name)
+	}
+}
+
+func TestAssetMatchIgnoresUnrelatedEntries(t *testing.T) {
+	rel := Release{Assets: mkAssets(
+		"README.md",
+		"nistru_v1.0.0_linux_amd64.tar.gz",
+		"source.zip",
+	)}
+	_, _, err := AssetMatch(rel, "darwin", "arm64")
+	if !errors.Is(err, ErrNoAssetForPlatform) {
+		t.Fatalf("err = %v, want ErrNoAssetForPlatform", err)
+	}
+}

--- a/internal/plugins/autoupdate/autoupdate.go
+++ b/internal/plugins/autoupdate/autoupdate.go
@@ -1,0 +1,623 @@
+// Package autoupdate is the first-party plugin that watches for new Nistru
+// releases and lets the user install them from the palette.
+//
+// Lifecycle:
+//   - plugin.Plugin entry is wired through the in-proc registry at editor
+//     startup; SetHost runs before Initialize is delivered.
+//   - Initialize kicks off a single background goroutine (the checker) that
+//     polls GitHub on an interval with jitter. The goroutine is the only
+//     owner of host I/O for background status-bar updates; everything else
+//     flows through PostNotif so effects arrive on the UI goroutine via the
+//     standard inbound channel.
+//   - Shutdown cancels the checker and waits briefly for it to exit.
+//
+// The install seam is intentionally minimal — T7 will replace noopInstaller
+// with a real binary-swap path. This file stays stable across that work.
+package autoupdate
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/savimcio/nistru/plugin"
+)
+
+const (
+	// defaultRepo is the public repository we poll when no override is
+	// supplied. Tests always set their own via WithRepo.
+	defaultRepo = "savimcio/nistru"
+
+	// defaultInterval is the ticker period between release checks.
+	defaultInterval = 1 * time.Hour
+
+	// shutdownGrace is the maximum time we wait for the checker goroutine
+	// to exit during Shutdown.
+	shutdownGrace = 500 * time.Millisecond
+
+	// envRepo, envChannel, envInterval, envDisable are the environment-
+	// variable overrides honoured by New().
+	envRepo     = "NISTRU_AUTOUPDATE_REPO"
+	envChannel  = "NISTRU_AUTOUPDATE_CHANNEL"
+	envInterval = "NISTRU_AUTOUPDATE_INTERVAL"
+	envDisable  = "NISTRU_AUTOUPDATE_DISABLE"
+)
+
+// Installer is the seam T7 will fill with the real binary swap. The noop
+// implementation in noop_installer.go is the default until then.
+type Installer interface {
+	Install(ctx context.Context, host *plugin.Host, rel Release, cur string) error
+	Rollback(ctx context.Context, host *plugin.Host) error
+}
+
+// Plugin is the in-process auto-update plugin. The zero value is not useful;
+// construct instances via New().
+type Plugin struct {
+	name string
+
+	repo     string
+	channel  string
+	current  string
+	interval time.Duration
+	disabled bool
+
+	client    *http.Client
+	installer Installer
+	now       func() time.Time
+	versionFn func() string
+	statePath string
+
+	mu        sync.Mutex
+	host      *plugin.Host
+	state     State
+	checker   *checker
+	shutdown  bool
+	ctxCancel context.CancelFunc
+}
+
+// Option configures Plugin at construction.
+type Option func(*Plugin)
+
+// WithRepo overrides the "owner/repo" string polled for releases.
+func WithRepo(repo string) Option {
+	return func(p *Plugin) { p.repo = repo }
+}
+
+// WithHTTPClient injects a custom *http.Client (tests point it at an
+// httptest.Server via a rewriting transport).
+func WithHTTPClient(c *http.Client) Option {
+	return func(p *Plugin) { p.client = c }
+}
+
+// WithInstaller swaps in a real installer once T7 lands. Tests use this to
+// assert the install/rollback dispatch path without touching the binary.
+func WithInstaller(i Installer) Option {
+	return func(p *Plugin) { p.installer = i }
+}
+
+// WithClock injects a now-func so time-dependent behaviour is deterministic
+// in tests. Defaults to time.Now.
+func WithClock(now func() time.Time) Option {
+	return func(p *Plugin) {
+		if now != nil {
+			p.now = now
+		}
+	}
+}
+
+// WithInterval overrides the ticker period. Tests use very short intervals
+// to exercise the loop without hanging.
+func WithInterval(d time.Duration) Option {
+	return func(p *Plugin) {
+		if d > 0 {
+			p.interval = d
+		}
+	}
+}
+
+// WithStatePath overrides the on-disk state file location. Tests pass
+// t.TempDir() paths so nothing leaks into the real user config dir.
+func WithStatePath(path string) Option {
+	return func(p *Plugin) { p.statePath = path }
+}
+
+// WithCurrent overrides the detected "current version" used for comparisons.
+// Tests use this seam to drive the "newer/older/equal" branches without
+// depending on runtime/debug.ReadBuildInfo.
+func WithCurrent(v string) Option {
+	return func(p *Plugin) { p.current = v }
+}
+
+// WithVersionFunc injects a function that resolves the running binary's
+// version at Initialize time. Tests use this so reconciliation logic can
+// be driven without depending on ldflags or ReadBuildInfo. When unset,
+// the plugin falls back to the package-level Current().
+func WithVersionFunc(fn func() string) Option {
+	return func(p *Plugin) {
+		if fn != nil {
+			p.versionFn = fn
+		}
+	}
+}
+
+// New returns a configured plugin with defaults filled in from the
+// environment. Env precedence: construction options > env vars > package
+// defaults. New never performs I/O; the background goroutine and state load
+// run inside OnEvent(Initialize).
+func New(opts ...Option) *Plugin {
+	p := &Plugin{
+		name:     "autoupdate",
+		repo:     defaultRepo,
+		interval: defaultInterval,
+		client:   &http.Client{Timeout: 10 * time.Second},
+		now:      time.Now,
+		current:  Current(),
+	}
+	p.installer = NewInstaller(WithStateUpdater(p.updateState))
+
+	// Env defaults are applied before explicit options so callers can still
+	// override them. Tests that want a deterministic environment should
+	// clear these vars via t.Setenv before constructing.
+	if v := strings.TrimSpace(os.Getenv(envRepo)); v != "" {
+		p.repo = v
+	}
+	if v := strings.TrimSpace(os.Getenv(envChannel)); v != "" {
+		p.channel = v
+	}
+	if v := strings.TrimSpace(os.Getenv(envInterval)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			p.interval = d
+		}
+	}
+	if os.Getenv(envDisable) == "1" {
+		p.disabled = true
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Name implements plugin.Plugin.
+func (p *Plugin) Name() string { return p.name }
+
+// Activation implements plugin.Plugin. The checker must come up at editor
+// launch so the status bar populates before the user interacts with
+// anything, hence onStart.
+func (p *Plugin) Activation() []string { return []string{"onStart"} }
+
+// SetHost implements plugin.HostAware. The host wires HostAware plugins
+// exactly once, before Initialize is dispatched.
+func (p *Plugin) SetHost(h *plugin.Host) {
+	p.mu.Lock()
+	p.host = h
+	p.mu.Unlock()
+}
+
+// OnEvent implements plugin.Plugin. All effects are empty; side effects flow
+// through the host's PostNotif channel so they arrive on the UI goroutine
+// via the normal inbound queue.
+func (p *Plugin) OnEvent(event any) []plugin.Effect {
+	switch ev := event.(type) {
+	case plugin.Initialize:
+		p.handleInitialize()
+		return nil
+	case plugin.ExecuteCommand:
+		p.handleExecute(ev)
+		return nil
+	case plugin.Shutdown:
+		p.stopChecker()
+		return nil
+	}
+	return nil
+}
+
+// Shutdown implements plugin.Plugin. Idempotent and safe to call without
+// a prior Shutdown event.
+func (p *Plugin) Shutdown() error {
+	p.stopChecker()
+	return nil
+}
+
+// handleInitialize loads persisted state, registers palette commands, and
+// spawns the checker goroutine. When NISTRU_AUTOUPDATE_DISABLE=1 we still
+// register commands (so the palette surfaces them and users can dispatch
+// install/rollback manually), but skip the background checker — "disabled"
+// refers to the polling loop, not the whole feature.
+func (p *Plugin) handleInitialize() {
+	p.mu.Lock()
+	if p.shutdown {
+		p.mu.Unlock()
+		return
+	}
+
+	// Resolve state path if not injected.
+	if p.statePath == "" {
+		if sp, err := StatePath(); err == nil {
+			p.statePath = sp
+		}
+	}
+
+	// Load persisted state; LoadState is forgiving and never errors on
+	// missing/corrupt files.
+	if p.statePath != "" {
+		if st, err := LoadState(p.statePath); err == nil {
+			p.state = st
+		}
+	}
+	// Channel precedence: explicit env > persisted state > default.
+	if p.channel != "" {
+		p.state.Channel = p.channel
+	} else if p.state.Channel == "" {
+		p.state.Channel = DefaultChannel()
+	}
+	host := p.host
+	pendingVersion := p.state.PendingRestartVersion
+	prevPath := p.state.PrevBinaryPath
+
+	if p.disabled {
+		p.mu.Unlock()
+		// Always register palette commands, even when the background checker
+		// is disabled via env — the user should still be able to run
+		// install/rollback on demand without flipping the env var.
+		registerCommands(host)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.ctxCancel = cancel
+
+	c := newChecker(p)
+	p.checker = c
+	p.mu.Unlock()
+
+	// Reconcile a prior install that has since been applied. If the running
+	// binary's version matches the pending one, the user has already
+	// restarted — clear the pending state and best-effort remove the .prev
+	// sibling so subsequent sessions don't leak it.
+	p.finalizePendingRestart(pendingVersion, prevPath)
+
+	registerCommands(host)
+	c.start(ctx)
+}
+
+// finalizePendingRestart clears PendingRestartVersion and PrevBinaryPath
+// when the running binary's version matches the pending one. Removes the
+// .prev file if it still exists — this is the "success finalisation" that
+// should have happened on restart. Best-effort: any error is dropped
+// silently because the user cannot act on it.
+func (p *Plugin) finalizePendingRestart(pendingVersion, prevPath string) {
+	if pendingVersion == "" {
+		return
+	}
+	running := p.runningVersion()
+	if CompareVersions(running, pendingVersion) != 0 {
+		// Still running the old binary — the restart hasn't happened yet,
+		// leave everything alone so rollback keeps working.
+		return
+	}
+	_ = p.updateState(func(s *State) {
+		s.PendingRestartVersion = ""
+		s.PrevBinaryPath = ""
+	})
+	if prevPath != "" {
+		if _, err := os.Stat(prevPath); err == nil {
+			_ = os.Remove(prevPath)
+		}
+	}
+}
+
+// runningVersion returns the current binary's version string. Prefers the
+// injected versionFn seam over the package-level Current() so tests can
+// drive reconciliation deterministically.
+func (p *Plugin) runningVersion() string {
+	if p.versionFn != nil {
+		return p.versionFn()
+	}
+	return Current()
+}
+
+// registerCommands fires the five commands/register notifications. The host
+// applies them synchronously inside PostNotif, so callers see them as
+// visible immediately.
+func registerCommands(host *plugin.Host) {
+	if host == nil {
+		return
+	}
+	cmds := []struct {
+		id, title string
+	}{
+		{"autoupdate:check", "Auto-update: check now"},
+		{"autoupdate:install", "Auto-update: install pending update"},
+		{"autoupdate:rollback", "Auto-update: rollback last install"},
+		{"autoupdate:switch-channel", "Auto-update: toggle release ↔ dev channel"},
+		{"autoupdate:release-notes", "Auto-update: show latest release notes"},
+	}
+	for _, c := range cmds {
+		_ = host.PostNotif("autoupdate", "commands/register", map[string]string{
+			"id":    c.id,
+			"title": c.title,
+		})
+	}
+}
+
+// handleExecute dispatches ExecuteCommand events to their handlers. Each
+// handler is responsible for surfacing errors via PostNotif — OnEvent never
+// returns effects, so we cannot propagate them through the return value.
+func (p *Plugin) handleExecute(ev plugin.ExecuteCommand) {
+	switch ev.ID {
+	case "autoupdate:check":
+		p.cmdCheck()
+	case "autoupdate:install":
+		p.cmdInstall()
+	case "autoupdate:rollback":
+		p.cmdRollback()
+	case "autoupdate:switch-channel":
+		p.cmdSwitchChannel()
+	case "autoupdate:release-notes":
+		p.cmdReleaseNotes()
+	}
+}
+
+// cmdCheck nudges the checker goroutine. A no-op if the checker is not
+// running (e.g. plugin disabled via env var).
+func (p *Plugin) cmdCheck() {
+	p.mu.Lock()
+	c := p.checker
+	p.mu.Unlock()
+	if c == nil {
+		return
+	}
+	c.nudge()
+}
+
+// cmdInstall dispatches to the configured installer with the last-seen
+// release. Errors are posted as ui/notify.
+func (p *Plugin) cmdInstall() {
+	p.mu.Lock()
+	host, inst, c, cur := p.host, p.installer, p.checker, p.current
+	p.mu.Unlock()
+	if inst == nil {
+		return
+	}
+	var rel Release
+	if c != nil {
+		if r := c.lastRelease.Load(); r != nil {
+			rel = *r
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := inst.Install(ctx, host, rel, cur); err != nil {
+		p.postError(host, err.Error())
+	}
+}
+
+// cmdRollback delegates to Installer.Rollback. Errors are surfaced via
+// ui/notify just like cmdInstall.
+func (p *Plugin) cmdRollback() {
+	p.mu.Lock()
+	host, inst := p.host, p.installer
+	p.mu.Unlock()
+	if inst == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := inst.Rollback(ctx, host); err != nil {
+		p.postError(host, err.Error())
+	}
+}
+
+// cmdSwitchChannel toggles state.Channel between "release" and "dev",
+// persists the new value, confirms via ui/notify, and nudges the checker.
+// All state mutation flows through updateState so a concurrent checker
+// tick or install cannot clobber the channel switch.
+func (p *Plugin) cmdSwitchChannel() {
+	var next string
+	err := p.updateState(func(s *State) {
+		cur := s.Channel
+		if cur == "" {
+			cur = DefaultChannel()
+		}
+		next = "dev"
+		if cur == "dev" {
+			next = "release"
+		}
+		s.Channel = next
+	})
+
+	p.mu.Lock()
+	host := p.host
+	c := p.checker
+	p.mu.Unlock()
+
+	if err != nil {
+		p.postError(host, "autoupdate: save channel: "+err.Error())
+	}
+	if host != nil {
+		_ = host.PostNotif("autoupdate", "ui/notify", map[string]string{
+			"level":   "info",
+			"message": "auto-update channel: " + next,
+		})
+	}
+	if c != nil {
+		c.nudge()
+	}
+}
+
+// cmdReleaseNotes writes the last-known release's body to a tempfile and
+// asks the editor to open it. If no notes are available, posts a notify.
+func (p *Plugin) cmdReleaseNotes() {
+	p.mu.Lock()
+	host, c := p.host, p.checker
+	p.mu.Unlock()
+
+	var rel Release
+	if c != nil {
+		if r := c.lastRelease.Load(); r != nil {
+			rel = *r
+		}
+	}
+	body := strings.TrimSpace(rel.Body)
+	if body == "" {
+		if host != nil {
+			_ = host.PostNotif("autoupdate", "ui/notify", map[string]string{
+				"level":   "info",
+				"message": "no release notes available",
+			})
+		}
+		return
+	}
+
+	path, err := writeReleaseNotes(rel)
+	if err != nil {
+		p.postError(host, "autoupdate: write release notes: "+err.Error())
+		return
+	}
+
+	// OpenFile is a plugin.Effect, but OnEvent for ExecuteCommand returns no
+	// effects (we're off the ExecuteCommand return path). Route it through
+	// PostNotif so the model's inbound queue picks it up alongside other
+	// asynchronous effects. The editor's model treats the pair as a hint to
+	// open the file; tests assert on the notification directly.
+	if host != nil {
+		_ = host.PostNotif("autoupdate", "editor/openFile", map[string]string{
+			"path": path,
+		})
+	}
+}
+
+// writeReleaseNotes persists rel.Body to a stable tempfile under the OS
+// temp dir and returns its absolute path. The file is intentionally not
+// removed; opening it in the editor requires it to stick around.
+func writeReleaseNotes(rel Release) (string, error) {
+	dir := os.TempDir()
+	name := "nistru-release-" + sanitizeTag(rel.TagName) + ".md"
+	path := dir + string(os.PathSeparator) + name
+	content := rel.Body
+	if title := strings.TrimSpace(rel.Name); title != "" {
+		content = "# " + title + "\n\n" + content
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// sanitizeTag produces a filesystem-safe variant of a release tag. Anything
+// outside [A-Za-z0-9._-] collapses to "_".
+func sanitizeTag(tag string) string {
+	if tag == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	b.Grow(len(tag))
+	for _, r := range tag {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// postError surfaces err as an error-level ui/notify. A helper so every
+// command site stays one-liner.
+func (p *Plugin) postError(host *plugin.Host, msg string) {
+	if host == nil {
+		return
+	}
+	_ = host.PostNotif("autoupdate", "ui/notify", map[string]string{
+		"level":   "error",
+		"message": msg,
+	})
+}
+
+// snapshotState returns a copy of the plugin's current state. Called by
+// the checker goroutine, which must not hold p.mu while performing I/O.
+func (p *Plugin) snapshotState() State {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.state
+}
+
+// updateState atomically reloads state from disk, applies mut, persists
+// the result, and updates the in-memory cache. Serialised via p.mu so
+// concurrent checker / install / rollback mutations cannot clobber each
+// other. The disk reload is intentional: any writer (including a stale
+// snapshot inside the checker goroutine) sees the most-recent persisted
+// state before its mutation is applied, so two concurrent updates to
+// disjoint fields compose rather than clobber.
+//
+// Returns the SaveState error, if any. An in-memory update still happens
+// even if persistence fails — callers treat state as advisory.
+func (p *Plugin) updateState(mut func(*State)) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	st := p.state
+	if p.statePath != "" {
+		if loaded, err := LoadState(p.statePath); err == nil {
+			st = loaded
+		}
+	}
+	if mut != nil {
+		mut(&st)
+	}
+	p.state = st
+	if p.statePath == "" {
+		return nil
+	}
+	return SaveState(p.statePath, st)
+}
+
+// stopChecker cancels the background goroutine and waits for it to exit
+// (up to shutdownGrace). Idempotent: a second call is a no-op.
+//
+// If the installer implements the optional `cleaner` interface, it is
+// invoked once after the checker is stopped so stale ".prev" files from a
+// prior successful restart can be garbage-collected. Errors from Cleanup
+// are swallowed — it is always best-effort.
+func (p *Plugin) stopChecker() {
+	p.mu.Lock()
+	if p.shutdown {
+		p.mu.Unlock()
+		return
+	}
+	p.shutdown = true
+	cancel := p.ctxCancel
+	c := p.checker
+	inst := p.installer
+	p.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if c != nil {
+		c.cancel(shutdownGrace)
+	}
+	if cl, ok := inst.(cleaner); ok {
+		ctx, cancelCleanup := context.WithTimeout(context.Background(), shutdownGrace)
+		_ = cl.Cleanup(ctx)
+		cancelCleanup()
+	}
+}
+
+// cleaner is the optional interface RealInstaller implements so the plugin
+// can garbage-collect stale ".prev" binaries on Shutdown.
+type cleaner interface {
+	Cleanup(ctx context.Context) error
+}
+
+// Compile-time assertions so a missing interface surfaces at build time.
+var (
+	_ plugin.Plugin    = (*Plugin)(nil)
+	_ plugin.HostAware = (*Plugin)(nil)
+)

--- a/internal/plugins/autoupdate/autoupdate_test.go
+++ b/internal/plugins/autoupdate/autoupdate_test.go
@@ -1,0 +1,316 @@
+package autoupdate
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/savimcio/nistru/plugin"
+)
+
+// -----------------------------------------------------------------------------
+// Shared test helpers (also used by checker_test.go).
+
+// newTestHost builds a plugin.Host with p registered as the only in-proc
+// plugin. The cleanup closure stops the plugin (so its goroutine exits)
+// before any t.TempDir registered earlier in the caller is removed.
+func newTestHost(t *testing.T, p *Plugin) *plugin.Host {
+	t.Helper()
+	reg := plugin.NewRegistry()
+	reg.RegisterInProc(p)
+	h := plugin.NewHost(reg)
+	if err := h.Start(""); err != nil {
+		t.Fatalf("host.Start: %v", err)
+	}
+	t.Cleanup(func() {
+		// Stop the plugin first. Host.Shutdown only dispatches Plugin.Shutdown
+		// for activated plugins, and we activate via direct OnEvent calls,
+		// so the host's own bookkeeping would otherwise skip us.
+		_ = p.Shutdown()
+		_ = h.Shutdown(time.Second)
+	})
+	return h
+}
+
+// nextNotif returns the next PluginNotifMsg on h's inbound channel, or nil
+// on timeout. One goroutine per call is fine — these tests drain tens of
+// messages at most.
+func nextNotif(h *plugin.Host, timeout time.Duration) *plugin.PluginNotifMsg {
+	out := make(chan plugin.PluginMsg, 1)
+	go func() {
+		if v := h.Recv()(); v != nil {
+			if m, ok := v.(plugin.PluginMsg); ok {
+				out <- m
+			}
+		}
+		close(out)
+	}()
+	select {
+	case m, ok := <-out:
+		if !ok {
+			return nil
+		}
+		if n, ok := m.(plugin.PluginNotifMsg); ok {
+			return &n
+		}
+		return nil
+	case <-time.After(timeout):
+		return nil
+	}
+}
+
+// waitForNotif pulls messages off h's inbound channel until match(n) returns
+// true or timeout elapses. Returns the matching notification or nil.
+func waitForNotif(h *plugin.Host, timeout time.Duration, match func(plugin.PluginNotifMsg) bool) *plugin.PluginNotifMsg {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		n := nextNotif(h, time.Until(deadline))
+		if n == nil {
+			return nil
+		}
+		if match(*n) {
+			return n
+		}
+	}
+	return nil
+}
+
+// waitUntil polls pred until true or timeout. Fails the test on timeout.
+func waitUntil(t *testing.T, timeout time.Duration, pred func() bool) {
+	t.Helper()
+	const pollEvery = 10 * time.Millisecond
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pred() {
+			return
+		}
+		time.Sleep(pollEvery)
+	}
+	if pred() {
+		return
+	}
+	t.Fatalf("waitUntil: condition not met within %s", timeout)
+}
+
+// newReleaseServerJSON serves body at every request and counts hits.
+func newReleaseServerJSON(t *testing.T, body string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// newTestPlugin builds a Plugin pointed at srv with a short interval and
+// a tempdir state file. Env overrides are cleared so the test is hermetic.
+// rewriteTransport is shared with github_test.go.
+func newTestPlugin(t *testing.T, srv *httptest.Server, current string, opts ...Option) *Plugin {
+	t.Helper()
+	t.Setenv(envDisable, "")
+	t.Setenv(envRepo, "")
+	t.Setenv(envChannel, "")
+	t.Setenv(envInterval, "")
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: rewriteTransport{base: http.DefaultTransport, toURL: srv.URL},
+	}
+	base := []Option{
+		WithRepo("owner/repo"),
+		WithHTTPClient(client),
+		WithInterval(50 * time.Millisecond),
+		WithStatePath(statePath),
+		WithCurrent(current),
+	}
+	base = append(base, opts...)
+	return New(base...)
+}
+
+// -----------------------------------------------------------------------------
+// Plugin-level tests (env gating, command registration, Execute dispatch,
+// shutdown). Checker-specific tests live in checker_test.go.
+
+func TestDisableEnvVarShortCircuits(t *testing.T) {
+	t.Setenv(envDisable, "1")
+	p := New(WithRepo("owner/repo"), WithInterval(10*time.Millisecond))
+	_ = newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+
+	p.mu.Lock()
+	gotChecker := p.checker
+	p.mu.Unlock()
+	if gotChecker != nil {
+		t.Fatalf("checker spawned despite NISTRU_AUTOUPDATE_DISABLE=1")
+	}
+}
+
+func TestInitializeRegistersCommands(t *testing.T) {
+	srv, _ := newReleaseServerJSON(t, `[]`)
+	p := newTestPlugin(t, srv, "v0.1.0")
+	h := newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+
+	// PostNotif's handleInternal applies commands/register synchronously,
+	// so Host.Commands() sees them immediately.
+	want := []string{
+		"autoupdate:check",
+		"autoupdate:install",
+		"autoupdate:rollback",
+		"autoupdate:switch-channel",
+		"autoupdate:release-notes",
+	}
+	cmds := h.Commands()
+	for _, id := range want {
+		ref, ok := cmds[id]
+		if !ok {
+			t.Fatalf("command %q not registered; have %+v", id, cmds)
+		}
+		if ref.Plugin != "autoupdate" {
+			t.Fatalf("command %q owner = %q, want autoupdate", id, ref.Plugin)
+		}
+	}
+}
+
+func TestExecuteCheckTriggersFetch(t *testing.T) {
+	srv, hits := newReleaseServerJSON(t, `[]`)
+	p := newTestPlugin(t, srv, "v0.1.0", WithInterval(time.Hour))
+	_ = newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+	waitUntil(t, 2*time.Second, func() bool { return hits.Load() >= 1 })
+	baseline := hits.Load()
+
+	_ = p.OnEvent(plugin.ExecuteCommand{ID: "autoupdate:check"})
+	waitUntil(t, 2*time.Second, func() bool { return hits.Load() > baseline })
+}
+
+func TestExecuteSwitchChannelPersists(t *testing.T) {
+	srv, _ := newReleaseServerJSON(t, `[]`)
+	p := newTestPlugin(t, srv, "v0.1.0", WithInterval(time.Hour))
+	_ = newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+
+	p.mu.Lock()
+	statePath := p.statePath
+	p.mu.Unlock()
+
+	_ = p.OnEvent(plugin.ExecuteCommand{ID: "autoupdate:switch-channel"})
+	waitUntil(t, 2*time.Second, func() bool {
+		st, err := LoadState(statePath)
+		return err == nil && st.Channel == "dev"
+	})
+	_ = p.OnEvent(plugin.ExecuteCommand{ID: "autoupdate:switch-channel"})
+	waitUntil(t, 2*time.Second, func() bool {
+		st, err := LoadState(statePath)
+		return err == nil && st.Channel == "release"
+	})
+}
+
+// recordingInstaller captures Install/Rollback invocations.
+type recordingInstaller struct {
+	mu           sync.Mutex
+	installCalls []struct {
+		Rel Release
+		Cur string
+	}
+	rollbacks int
+}
+
+func (r *recordingInstaller) Install(_ context.Context, _ *plugin.Host, rel Release, cur string) error {
+	r.mu.Lock()
+	r.installCalls = append(r.installCalls, struct {
+		Rel Release
+		Cur string
+	}{Rel: rel, Cur: cur})
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *recordingInstaller) Rollback(_ context.Context, _ *plugin.Host) error {
+	r.mu.Lock()
+	r.rollbacks++
+	r.mu.Unlock()
+	return nil
+}
+
+func TestExecuteInstallCallsInstaller(t *testing.T) {
+	srv, _ := newReleaseServerJSON(t, oneStableNewerJSON)
+	inst := &recordingInstaller{}
+	p := newTestPlugin(t, srv, "v0.1.0",
+		WithInstaller(inst),
+		WithInterval(time.Hour),
+	)
+	_ = newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+	// Wait until the checker has cached a Release via its initial tick.
+	waitUntil(t, 2*time.Second, func() bool {
+		p.mu.Lock()
+		c := p.checker
+		p.mu.Unlock()
+		return c != nil && c.lastRelease.Load() != nil
+	})
+
+	_ = p.OnEvent(plugin.ExecuteCommand{ID: "autoupdate:install"})
+	waitUntil(t, 2*time.Second, func() bool {
+		inst.mu.Lock()
+		defer inst.mu.Unlock()
+		return len(inst.installCalls) == 1
+	})
+	inst.mu.Lock()
+	got := inst.installCalls[0]
+	inst.mu.Unlock()
+	if got.Cur != "v0.1.0" {
+		t.Fatalf("installer.cur = %q, want v0.1.0", got.Cur)
+	}
+	if got.Rel.TagName != "v99.0.0" {
+		t.Fatalf("installer.rel.TagName = %q, want v99.0.0", got.Rel.TagName)
+	}
+
+	_ = p.OnEvent(plugin.ExecuteCommand{ID: "autoupdate:rollback"})
+	waitUntil(t, 2*time.Second, func() bool {
+		inst.mu.Lock()
+		defer inst.mu.Unlock()
+		return inst.rollbacks == 1
+	})
+}
+
+func TestShutdownStopsCheckerCleanly(t *testing.T) {
+	srv, _ := newReleaseServerJSON(t, `[]`)
+	p := newTestPlugin(t, srv, "v0.1.0")
+	_ = newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+
+	p.mu.Lock()
+	c := p.checker
+	p.mu.Unlock()
+	if c == nil {
+		t.Fatalf("checker did not start")
+	}
+
+	_ = p.OnEvent(plugin.Shutdown{})
+	select {
+	case <-c.done:
+	case <-time.After(2 * shutdownGrace):
+		t.Fatalf("checker did not exit within %s", 2*shutdownGrace)
+	}
+
+	if err := p.Shutdown(); err != nil {
+		t.Fatalf("second Shutdown: %v", err)
+	}
+}

--- a/internal/plugins/autoupdate/checker.go
+++ b/internal/plugins/autoupdate/checker.go
@@ -1,0 +1,222 @@
+package autoupdate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/savimcio/nistru/plugin"
+)
+
+// checker is the long-running background loop that polls GitHub for new
+// releases. It lives inside Plugin and owns a single goroutine started from
+// start(); stop() cancels that goroutine and waits for it to exit.
+//
+// Ticker cadence: one fire immediately on start so the status bar populates
+// as soon as the editor launches, then every interval*(0.9..1.1) with jitter.
+// The triggerNow channel short-circuits the wait for the "check now" palette
+// command and for channel switches.
+type checker struct {
+	interval time.Duration
+	now      func() time.Time
+	rng      *rand.Rand
+	rngMu    sync.Mutex
+
+	client  *http.Client
+	repo    string
+	current string
+
+	host *plugin.Host
+
+	// getState reads the shared Plugin state. updateState applies a
+	// read-modify-write under the plugin mutex (reloading from disk first
+	// so concurrent writers composed on disjoint fields do not clobber).
+	// We do not hold a long-lived pointer into Plugin.state because the
+	// plugin serialises all state access under its own mutex.
+	getState    func() State
+	updateState func(func(*State)) error
+
+	triggerNow chan struct{}
+	stop       chan struct{}
+	done       chan struct{}
+
+	lastRelease atomic.Pointer[Release]
+}
+
+// newChecker wires up a checker with sane defaults. The caller must still
+// invoke start(ctx) to kick off the goroutine.
+func newChecker(p *Plugin) *checker {
+	return &checker{
+		interval:    p.interval,
+		now:         p.now,
+		rng:         rand.New(rand.NewSource(p.now().UnixNano())),
+		client:      p.client,
+		repo:        p.repo,
+		current:     p.current,
+		host:        p.host,
+		getState:    p.snapshotState,
+		updateState: p.updateState,
+		triggerNow:  make(chan struct{}, 1),
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+}
+
+// start launches the ticker goroutine. It is idempotent only relative to the
+// owning Plugin, which never calls start() twice for the same checker.
+func (c *checker) start(ctx context.Context) {
+	go c.loop(ctx)
+}
+
+// loop is the body of the checker goroutine. It performs one immediate tick,
+// then waits on a mix of timer, manual trigger, stop, and ctx.Done.
+func (c *checker) loop(ctx context.Context) {
+	defer close(c.done)
+
+	c.tick(ctx)
+
+	for {
+		wait := c.nextInterval()
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-c.stop:
+			timer.Stop()
+			return
+		case <-c.triggerNow:
+			timer.Stop()
+			c.tick(ctx)
+		case <-timer.C:
+			c.tick(ctx)
+		}
+	}
+}
+
+// nextInterval returns the base interval scaled by a jitter factor in
+// [0.9, 1.1). The factor is drawn from a package-local *rand.Rand so the
+// global math/rand stream is untouched.
+func (c *checker) nextInterval() time.Duration {
+	if c.interval <= 0 {
+		return 0
+	}
+	c.rngMu.Lock()
+	factor := 0.9 + c.rng.Float64()*0.2
+	c.rngMu.Unlock()
+	return time.Duration(float64(c.interval) * factor)
+}
+
+// nudge attempts a non-blocking send on triggerNow. If the channel already
+// has a pending trigger, we silently drop the second one — the goroutine
+// will still pick up the pending signal on the next iteration, which
+// coalesces bursts naturally.
+func (c *checker) nudge() {
+	select {
+	case c.triggerNow <- struct{}{}:
+	default:
+	}
+}
+
+// tick performs one end-to-end fetch + compare + publish cycle. Any error
+// is logged to stderr and the tick returns quietly so the next interval
+// still fires. State is persisted best-effort on every tick.
+func (c *checker) tick(ctx context.Context) {
+	owner, repo := splitRepo(c.repo)
+	if owner == "" || repo == "" {
+		fmt.Fprintf(os.Stderr, "autoupdate: invalid repo %q; skipping tick\n", c.repo)
+		return
+	}
+
+	releases, err := FetchReleases(ctx, c.client, owner, repo)
+	if err != nil {
+		if rl, ok := errors.AsType[*RateLimitError](err); ok {
+			fmt.Fprintf(os.Stderr, "autoupdate: rate limited, retry after %s\n", rl.RetryAfter)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "autoupdate: fetch releases: %v\n", err)
+		return
+	}
+
+	st := c.getState()
+	channel := st.Channel
+	if channel == "" {
+		channel = DefaultChannel()
+	}
+
+	latest, ok := LatestFor(channel, releases)
+	if !ok {
+		// Nothing to publish; still record that we checked. Goes through
+		// updateState so a concurrent install/rollback cannot get its
+		// PendingRestartVersion / PrevBinaryPath fields clobbered.
+		now := c.now()
+		if err := c.updateState(func(s *State) { s.LastChecked = now }); err != nil {
+			fmt.Fprintf(os.Stderr, "autoupdate: save state: %v\n", err)
+		}
+		return
+	}
+	// Remember the latest known release so palette commands can reach it.
+	relCopy := latest
+	c.lastRelease.Store(&relCopy)
+
+	tag := NormalizeVersion(latest.TagName)
+	cmp := CompareVersions(c.current, latest.TagName)
+	if cmp < 0 {
+		// Newer release available — show it in the status bar.
+		_ = c.host.PostNotif("autoupdate", "statusBar/set", map[string]string{
+			"segment": "autoupdate",
+			"text":    "↑ " + tag + " available",
+			"color":   "green",
+		})
+	} else {
+		// Up to date — clear any previously shown segment.
+		_ = c.host.PostNotif("autoupdate", "statusBar/set", map[string]string{
+			"segment": "autoupdate",
+			"text":    "",
+		})
+	}
+
+	now := c.now()
+	latestTag := latest.TagName
+	if err := c.updateState(func(s *State) {
+		s.LastChecked = now
+		s.LastSeenVersion = latestTag
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "autoupdate: save state: %v\n", err)
+	}
+}
+
+// cancel closes stop and waits up to the given timeout for the goroutine to
+// exit. Callers that don't care about the wait (e.g. GC cleanup) can pass 0.
+func (c *checker) cancel(wait time.Duration) {
+	select {
+	case <-c.stop:
+		// Already closed — cancel is idempotent.
+	default:
+		close(c.stop)
+	}
+	if wait <= 0 {
+		return
+	}
+	select {
+	case <-c.done:
+	case <-time.After(wait):
+	}
+}
+
+// splitRepo parses "owner/repo" into its two components. Empty/invalid input
+// returns two empty strings and the caller skips this tick.
+func splitRepo(s string) (string, string) {
+	i := strings.IndexByte(s, '/')
+	if i <= 0 || i == len(s)-1 {
+		return "", ""
+	}
+	return s[:i], s[i+1:]
+}

--- a/internal/plugins/autoupdate/checker_test.go
+++ b/internal/plugins/autoupdate/checker_test.go
@@ -1,0 +1,151 @@
+package autoupdate
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/savimcio/nistru/plugin"
+)
+
+// Fixtures shared across checker-level tests.
+
+// oneStableNewerJSON is a single stable release newer than v0.1.0.
+const oneStableNewerJSON = `[
+  {"tag_name":"v99.0.0","name":"99.0.0","body":"big release","published_at":"2026-03-10T12:00:00Z","prerelease":false,"draft":false}
+]`
+
+// oneStableSameJSON is a single stable release at v0.1.0 (matches the
+// "current" we inject in tests).
+const oneStableSameJSON = `[
+  {"tag_name":"v0.1.0","name":"0.1.0","published_at":"2026-01-01T12:00:00Z","prerelease":false,"draft":false}
+]`
+
+// mixedReleasesJSON has one stable (v1.5.0) and one newer prerelease
+// (v2.0.0-rc1). Release channel picks v1.5.0; dev channel picks v2.0.0-rc1.
+const mixedReleasesJSON = `[
+  {"tag_name":"v2.0.0-rc1","name":"2.0.0-rc1","published_at":"2026-03-10T12:00:00Z","prerelease":true,"draft":false},
+  {"tag_name":"v1.5.0","name":"1.5.0","published_at":"2026-02-01T12:00:00Z","prerelease":false,"draft":false}
+]`
+
+// statusMatcher returns a match func for waitForNotif that accepts a
+// statusBar/set with the given segment and a text containing needle. An
+// empty needle matches an empty text (the "clear segment" case).
+func statusMatcher(segment, needle string) func(plugin.PluginNotifMsg) bool {
+	return func(n plugin.PluginNotifMsg) bool {
+		if n.Method != "statusBar/set" {
+			return false
+		}
+		var payload struct {
+			Segment string `json:"segment"`
+			Text    string `json:"text"`
+			Color   string `json:"color"`
+		}
+		if err := json.Unmarshal(n.Params, &payload); err != nil {
+			return false
+		}
+		if payload.Segment != segment {
+			return false
+		}
+		if needle == "" {
+			return payload.Text == ""
+		}
+		return strings.Contains(payload.Text, needle)
+	}
+}
+
+func TestCheckerDetectsNewerRelease(t *testing.T) {
+	srv, _ := newReleaseServerJSON(t, oneStableNewerJSON)
+	p := newTestPlugin(t, srv, "v0.1.0")
+	h := newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+
+	n := waitForNotif(h, 2*time.Second, statusMatcher("autoupdate", "v99.0.0"))
+	if n == nil {
+		t.Fatalf("did not observe a statusBar/set mentioning v99.0.0")
+	}
+	// Assert the color is green so a future change to clearing semantics is
+	// caught by the test.
+	var payload struct {
+		Color string `json:"color"`
+	}
+	if err := json.Unmarshal(n.Params, &payload); err != nil || payload.Color != "green" {
+		t.Fatalf("statusBar/set color = %q, want green (err=%v)", payload.Color, err)
+	}
+}
+
+func TestCheckerNoUpdateClearsSegment(t *testing.T) {
+	srv, _ := newReleaseServerJSON(t, oneStableSameJSON)
+	p := newTestPlugin(t, srv, "v0.1.0")
+	h := newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+
+	if n := waitForNotif(h, 2*time.Second, statusMatcher("autoupdate", "")); n == nil {
+		t.Fatalf("did not observe a clearing statusBar/set")
+	}
+}
+
+func TestCheckerRespectsChannel(t *testing.T) {
+	srv, _ := newReleaseServerJSON(t, mixedReleasesJSON)
+	// Current is older than both releases so the channel — not the compare
+	// — decides which version the checker publishes.
+	p := newTestPlugin(t, srv, "v0.5.0")
+	h := newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+	if n := waitForNotif(h, 2*time.Second, statusMatcher("autoupdate", "v1.5.0")); n == nil {
+		t.Fatalf("release channel: expected v1.5.0 notif, got none")
+	}
+
+	// Toggle to dev — the palette command flips state and nudges the checker.
+	_ = p.OnEvent(plugin.ExecuteCommand{ID: "autoupdate:switch-channel"})
+	if n := waitForNotif(h, 2*time.Second, statusMatcher("autoupdate", "v2.0.0-rc1")); n == nil {
+		t.Fatalf("dev channel: expected v2.0.0-rc1 notif, got none")
+	}
+}
+
+func TestCheckerJitterStaysInEnvelope(t *testing.T) {
+	// Pure-helper test — no goroutines, no time.Sleep. Drawing 200
+	// intervals from nextInterval should always land within ±10% of the
+	// base, which is the contract the checker loop relies on.
+	srv, _ := newReleaseServerJSON(t, `[]`)
+	p := newTestPlugin(t, srv, "v0.1.0", WithInterval(100*time.Millisecond))
+	c := newChecker(p)
+
+	base := p.interval
+	low := time.Duration(float64(base) * 0.9)
+	high := time.Duration(float64(base) * 1.1)
+	for i := range 200 {
+		got := c.nextInterval()
+		if got < low || got > high {
+			t.Fatalf("iter %d: nextInterval = %s, want in [%s, %s]", i, got, low, high)
+		}
+	}
+}
+
+func TestSplitRepo(t *testing.T) {
+	cases := []struct {
+		in          string
+		owner, name string
+		valid       bool
+	}{
+		{"savimcio/nistru", "savimcio", "nistru", true},
+		{"", "", "", false},
+		{"noslash", "", "", false},
+		{"/trailing", "", "", false},
+		{"leading/", "", "", false},
+	}
+	for _, tc := range cases {
+		o, n := splitRepo(tc.in)
+		got := o != "" && n != ""
+		if got != tc.valid {
+			t.Fatalf("splitRepo(%q) valid=%v, want %v", tc.in, got, tc.valid)
+		}
+		if tc.valid && (o != tc.owner || n != tc.name) {
+			t.Fatalf("splitRepo(%q) = (%q,%q), want (%q,%q)", tc.in, o, n, tc.owner, tc.name)
+		}
+	}
+}

--- a/internal/plugins/autoupdate/github.go
+++ b/internal/plugins/autoupdate/github.go
@@ -1,0 +1,184 @@
+package autoupdate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// githubReleasesURL is the GitHub REST endpoint template for listing releases.
+// We intentionally hit /releases (not /releases/latest) so callers can filter
+// by channel (release vs dev) over the full set.
+const githubReleasesURL = "https://api.github.com/repos/%s/%s/releases"
+
+// maxReleasesBodyBytes caps the response body we will read from GitHub to
+// guard against a hostile or misbehaving server returning an unbounded stream.
+const maxReleasesBodyBytes = 1 << 20 // 1 MiB
+
+// defaultFetchTimeout is the overall timeout applied to FetchReleases when
+// the incoming context does not already carry a deadline.
+const defaultFetchTimeout = 10 * time.Second
+
+// Release is a subset of the GitHub Releases API payload. Only fields the
+// auto-update flow actually consumes are decoded; everything else is
+// discarded by encoding/json.
+type Release struct {
+	TagName     string    `json:"tag_name"`
+	Name        string    `json:"name"`
+	Body        string    `json:"body"`
+	Prerelease  bool      `json:"prerelease"`
+	Draft       bool      `json:"draft"`
+	PublishedAt time.Time `json:"published_at"`
+	Assets      []Asset   `json:"assets"`
+}
+
+// Asset describes a single downloadable artifact attached to a Release.
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+	ContentType        string `json:"content_type"`
+}
+
+// RateLimitError is returned by FetchReleases when the GitHub API responds
+// with HTTP 429. It surfaces the server-suggested Retry-After window so the
+// caller (not this package) can decide whether to back off, skip, or abort.
+type RateLimitError struct {
+	RetryAfter time.Duration
+}
+
+// Error implements the error interface.
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("github: rate limited, retry after %s", e.RetryAfter)
+}
+
+// FetchReleases retrieves the full list of releases for owner/repo from the
+// GitHub REST API. Draft releases are filtered out; prereleases are kept so
+// callers on the "dev" channel can see them.
+//
+// Behavior:
+//   - URL: https://api.github.com/repos/{owner}/{repo}/releases
+//   - Headers: User-Agent, Accept, X-GitHub-Api-Version are set.
+//   - If ctx has no deadline, a 10s timeout is applied.
+//   - If client is nil, a fresh *http.Client with a 10s timeout is used.
+//   - Response body is capped at 1 MiB via io.LimitReader.
+//   - HTTP 429 -> *RateLimitError with RetryAfter parsed from the header.
+//   - Other non-2xx -> error including the status.
+//
+// The returned slice preserves the API's order (newest first by creation
+// date, per GitHub docs); callers must not assume any additional sort.
+func FetchReleases(ctx context.Context, client *http.Client, owner, repo string) ([]Release, error) {
+	if client == nil {
+		client = &http.Client{Timeout: defaultFetchTimeout}
+	}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultFetchTimeout)
+		defer cancel()
+	}
+
+	url := fmt.Sprintf(githubReleasesURL, owner, repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("github: build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "nistru-autoupdate")
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, &RateLimitError{RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After"))}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("github: unexpected status %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	body := io.LimitReader(resp.Body, maxReleasesBodyBytes)
+	var raw []Release
+	if err := json.NewDecoder(body).Decode(&raw); err != nil {
+		return nil, fmt.Errorf("github: decode response: %w", err)
+	}
+
+	out := raw[:0]
+	for _, r := range raw {
+		if r.Draft {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// parseRetryAfter interprets a Retry-After header value. GitHub documents
+// delta-seconds; we also accept HTTP-date per RFC 7231 for robustness. If
+// the header is missing or unparseable, a zero duration is returned — the
+// caller will treat that as "no server guidance".
+func parseRetryAfter(h string) time.Duration {
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(h); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(h); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// LatestFor returns the best matching release for the given channel.
+//
+//   - "release" -> newest non-prerelease by PublishedAt.
+//   - "dev"     -> newest overall by PublishedAt, including prereleases.
+//   - anything else -> (Release{}, false).
+//
+// The boolean is false when no release in the slice satisfies the channel.
+func LatestFor(channel string, releases []Release) (Release, bool) {
+	switch channel {
+	case "release":
+		return pickLatest(releases, func(r Release) bool { return !r.Prerelease })
+	case "dev":
+		return pickLatest(releases, func(Release) bool { return true })
+	default:
+		return Release{}, false
+	}
+}
+
+// pickLatest returns the release with the greatest PublishedAt among those
+// satisfying keep. Ties are broken by first-seen (stable for equal times).
+func pickLatest(releases []Release, keep func(Release) bool) (Release, bool) {
+	var (
+		best  Release
+		found bool
+	)
+	for _, r := range releases {
+		if !keep(r) {
+			continue
+		}
+		if !found || r.PublishedAt.After(best.PublishedAt) {
+			best = r
+			found = true
+		}
+	}
+	if !found {
+		return Release{}, false
+	}
+	return best, true
+}
+
+// Compile-time assertion that *RateLimitError satisfies error.
+var _ error = (*RateLimitError)(nil)

--- a/internal/plugins/autoupdate/github_test.go
+++ b/internal/plugins/autoupdate/github_test.go
@@ -1,0 +1,256 @@
+package autoupdate
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// threeReleasesJSON has two stable releases plus one prerelease. No drafts.
+const threeReleasesJSON = `[
+  {"tag_name":"v1.3.0","name":"1.3.0","published_at":"2026-03-10T12:00:00Z","prerelease":false,"draft":false},
+  {"tag_name":"v1.3.0-rc1","name":"1.3.0-rc1","published_at":"2026-03-05T12:00:00Z","prerelease":true,"draft":false},
+  {"tag_name":"v1.2.0","name":"1.2.0","published_at":"2026-02-01T12:00:00Z","prerelease":false,"draft":false}
+]`
+
+// oneDraftJSON has a draft that must be filtered out.
+const oneDraftJSON = `[
+  {"tag_name":"v2.0.0","published_at":"2026-04-01T00:00:00Z","prerelease":false,"draft":false},
+  {"tag_name":"v2.1.0-draft","published_at":"2026-04-15T00:00:00Z","prerelease":false,"draft":true}
+]`
+
+// newReleasesServer returns an httptest.Server that serves body with status
+// and an optional Retry-After header. It also records the last observed
+// request so tests can assert headers.
+func newReleasesServer(t *testing.T, status int, body string, retryAfter string) (*httptest.Server, *http.Request) {
+	t.Helper()
+	var lastReq http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastReq = *r.Clone(r.Context())
+		if retryAfter != "" {
+			w.Header().Set("Retry-After", retryAfter)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &lastReq
+}
+
+// fetchVia hits srv by rewriting the base URL at the http.Client transport
+// layer. This avoids exposing a seam in production code for a test-only need.
+func fetchVia(ctx context.Context, srv *httptest.Server) ([]Release, error) {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: rewriteTransport{
+			base:  http.DefaultTransport,
+			toURL: srv.URL,
+		},
+	}
+	return FetchReleases(ctx, client, "owner", "repo")
+}
+
+// rewriteTransport forwards every request to toURL, preserving method and
+// headers. Its only job is to let tests point FetchReleases at httptest.
+type rewriteTransport struct {
+	base  http.RoundTripper
+	toURL string
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	u, err := clone.URL.Parse(t.toURL)
+	if err != nil {
+		return nil, err
+	}
+	clone.URL.Scheme = u.Scheme
+	clone.URL.Host = u.Host
+	clone.Host = u.Host
+	return t.base.RoundTrip(clone)
+}
+
+func TestFetchReleasesOK(t *testing.T) {
+	srv, _ := newReleasesServer(t, http.StatusOK, threeReleasesJSON, "")
+	got, err := fetchVia(context.Background(), srv)
+	if err != nil {
+		t.Fatalf("FetchReleases error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3", len(got))
+	}
+	wantTags := []string{"v1.3.0", "v1.3.0-rc1", "v1.2.0"}
+	for i, r := range got {
+		if r.TagName != wantTags[i] {
+			t.Errorf("got[%d].TagName = %q, want %q", i, r.TagName, wantTags[i])
+		}
+	}
+	if got[0].Prerelease {
+		t.Errorf("got[0].Prerelease = true, want false")
+	}
+	if !got[1].Prerelease {
+		t.Errorf("got[1].Prerelease = false, want true")
+	}
+}
+
+func TestFetchReleasesFiltersDrafts(t *testing.T) {
+	srv, _ := newReleasesServer(t, http.StatusOK, oneDraftJSON, "")
+	got, err := fetchVia(context.Background(), srv)
+	if err != nil {
+		t.Fatalf("FetchReleases error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1 (draft should be filtered)", len(got))
+	}
+	if got[0].TagName != "v2.0.0" {
+		t.Errorf("got[0].TagName = %q, want v2.0.0", got[0].TagName)
+	}
+}
+
+func TestFetchReleasesEmpty(t *testing.T) {
+	srv, _ := newReleasesServer(t, http.StatusOK, `[]`, "")
+	got, err := fetchVia(context.Background(), srv)
+	if err != nil {
+		t.Fatalf("FetchReleases error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d, want 0", len(got))
+	}
+}
+
+func TestFetchReleasesMalformedJSON(t *testing.T) {
+	srv, _ := newReleasesServer(t, http.StatusOK, `not json`, "")
+	_, err := fetchVia(context.Background(), srv)
+	if err == nil {
+		t.Fatalf("FetchReleases err = nil, want decode error")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Errorf("err = %v, want message containing 'decode'", err)
+	}
+}
+
+func TestFetchReleasesRateLimited(t *testing.T) {
+	srv, _ := newReleasesServer(t, http.StatusTooManyRequests, `{"message":"rate limited"}`, "42")
+	_, err := fetchVia(context.Background(), srv)
+	if err == nil {
+		t.Fatalf("FetchReleases err = nil, want *RateLimitError")
+	}
+	var rle *RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("err type = %T, want *RateLimitError (err=%v)", err, err)
+	}
+	if rle.RetryAfter != 42*time.Second {
+		t.Errorf("RetryAfter = %s, want 42s", rle.RetryAfter)
+	}
+}
+
+func TestFetchReleases500(t *testing.T) {
+	srv, _ := newReleasesServer(t, http.StatusInternalServerError, `boom`, "")
+	_, err := fetchVia(context.Background(), srv)
+	if err == nil {
+		t.Fatalf("FetchReleases err = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("err = %v, want message mentioning 500", err)
+	}
+}
+
+func TestFetchReleasesBodyCap(t *testing.T) {
+	// Serve ~2 MiB of junk. JSON decode will fail because the payload is
+	// both non-JSON and, after capping at 1 MiB, truncated. The assertion
+	// is that we don't OOM and we do surface a decode error.
+	big := strings.Repeat("x", 2<<20)
+	srv, _ := newReleasesServer(t, http.StatusOK, big, "")
+	_, err := fetchVia(context.Background(), srv)
+	if err == nil {
+		t.Fatalf("FetchReleases err = nil, want decode error from truncated payload")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Errorf("err = %v, want message containing 'decode'", err)
+	}
+}
+
+func TestFetchReleasesUserAgent(t *testing.T) {
+	srv, lastReq := newReleasesServer(t, http.StatusOK, `[]`, "")
+	if _, err := fetchVia(context.Background(), srv); err != nil {
+		t.Fatalf("FetchReleases error: %v", err)
+	}
+	if got := lastReq.Header.Get("User-Agent"); got != "nistru-autoupdate" {
+		t.Errorf("User-Agent = %q, want nistru-autoupdate", got)
+	}
+	if got := lastReq.Header.Get("Accept"); got != "application/vnd.github+json" {
+		t.Errorf("Accept = %q, want application/vnd.github+json", got)
+	}
+	if got := lastReq.Header.Get("X-GitHub-Api-Version"); got != "2022-11-28" {
+		t.Errorf("X-GitHub-Api-Version = %q, want 2022-11-28", got)
+	}
+}
+
+// releasesFixture builds a small slice for LatestFor tests.
+func releasesFixture() []Release {
+	return []Release{
+		{TagName: "v1.3.0-rc1", Prerelease: true, PublishedAt: mustTime("2026-03-20T00:00:00Z")},
+		{TagName: "v1.2.0", Prerelease: false, PublishedAt: mustTime("2026-02-01T00:00:00Z")},
+		{TagName: "v1.3.0", Prerelease: false, PublishedAt: mustTime("2026-03-10T00:00:00Z")},
+		{TagName: "v1.1.0", Prerelease: false, PublishedAt: mustTime("2026-01-01T00:00:00Z")},
+	}
+}
+
+func mustTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestLatestForRelease(t *testing.T) {
+	got, ok := LatestFor("release", releasesFixture())
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if got.TagName != "v1.3.0" {
+		t.Errorf("TagName = %q, want v1.3.0 (latest stable)", got.TagName)
+	}
+}
+
+func TestLatestForDev(t *testing.T) {
+	got, ok := LatestFor("dev", releasesFixture())
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if got.TagName != "v1.3.0-rc1" {
+		t.Errorf("TagName = %q, want v1.3.0-rc1 (latest overall)", got.TagName)
+	}
+}
+
+func TestLatestForEmpty(t *testing.T) {
+	got, ok := LatestFor("release", nil)
+	if ok {
+		t.Fatalf("ok = true, want false")
+	}
+	if got.TagName != "" || len(got.Assets) != 0 {
+		t.Errorf("got = %+v, want zero Release", got)
+	}
+	got, ok = LatestFor("dev", []Release{})
+	if ok {
+		t.Fatalf("ok = true for empty dev, want false")
+	}
+	if got.TagName != "" || len(got.Assets) != 0 {
+		t.Errorf("got = %+v, want zero Release", got)
+	}
+}
+
+func TestLatestForUnknownChannel(t *testing.T) {
+	got, ok := LatestFor("foo", releasesFixture())
+	if ok {
+		t.Fatalf("ok = true for unknown channel, want false")
+	}
+	if got.TagName != "" || len(got.Assets) != 0 {
+		t.Errorf("got = %+v, want zero Release", got)
+	}
+}

--- a/internal/plugins/autoupdate/install.go
+++ b/internal/plugins/autoupdate/install.go
@@ -1,0 +1,746 @@
+package autoupdate
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/savimcio/nistru/plugin"
+)
+
+// Defaults for RealInstaller.
+const (
+	defaultMaxAssetBytes      = int64(100 << 20) // 100 MiB
+	defaultInstallHTTPTimeout = 60 * time.Second
+	maxChecksumsBodyBytes     = int64(64 << 10) // 64 KiB cap on checksums.txt
+
+	// defaultMaxArchiveBytes caps total decompressed bytes read across all
+	// tar entries — defence in depth against a "tar bomb" that compresses
+	// gigabytes of zeros into kilobytes. Independent of WithMaxSize, which
+	// bounds the single extracted binary.
+	defaultMaxArchiveBytes = int64(500 << 20) // 500 MiB
+
+	// defaultMaxArchiveEntries caps tar header count so a pathological
+	// archive with millions of zero-byte entries cannot wedge the reader.
+	defaultMaxArchiveEntries = 10_000
+)
+
+// errPreflightWindows is the internal sentinel signalling the caller to
+// emit the notify-only upgrade instructions and return nil from Install.
+var errPreflightWindows = errors.New("autoupdate: windows in-place swap unsupported")
+
+// RealInstaller is the production Installer: it downloads release archives,
+// verifies their SHA-256 against the release's checksums.txt, atomically
+// swaps the running binary on POSIX, and leaves a ".prev" sibling for
+// Rollback. On Windows it short-circuits to a notify-only fallback.
+//
+// RealInstaller is safe for concurrent use by the plugin's single palette
+// dispatch; tests can drive Install/Rollback/Cleanup directly. All state
+// persistence flows through the updater supplied via WithStateUpdater —
+// this is what serialises Install/Rollback's field updates against the
+// checker goroutine's own LastChecked/LastSeenVersion writes. When no
+// updater is wired the installer falls back to a local read-modify-write
+// against statePath, which is race-prone and only appropriate for
+// stand-alone tests of the installer.
+type RealInstaller struct {
+	executable   func() (string, error)
+	goos         string
+	goarch       string
+	client       *http.Client
+	maxSize      int64
+	maxArchive   int64
+	maxEntries   int
+	statePath    string
+	freeBytes    func(dir string) (int64, error)
+	updateStateF func(func(*State)) error
+}
+
+// InstallerOption configures a RealInstaller.
+type InstallerOption func(*RealInstaller)
+
+// WithExecutableFunc injects the function used to resolve the path of the
+// running binary. Tests always pass a closure returning a path under
+// t.TempDir() so no test ever touches the real os.Executable result.
+func WithExecutableFunc(fn func() (string, error)) InstallerOption {
+	return func(r *RealInstaller) { r.executable = fn }
+}
+
+// WithGoos overrides runtime.GOOS for testing the windows notify path and
+// platform-asset mismatch flows.
+func WithGoos(s string) InstallerOption {
+	return func(r *RealInstaller) { r.goos = s }
+}
+
+// WithGoarch overrides runtime.GOARCH for asset-selection tests.
+func WithGoarch(s string) InstallerOption {
+	return func(r *RealInstaller) { r.goarch = s }
+}
+
+// WithInstallerHTTPClient injects an HTTP client. Tests point it at an
+// httptest.Server and rely on absolute BrowserDownloadURLs served there.
+func WithInstallerHTTPClient(c *http.Client) InstallerOption {
+	return func(r *RealInstaller) { r.client = c }
+}
+
+// WithMaxSize caps the bytes we will read from the asset server. Exceeding
+// maxSize mid-download aborts with an error and deletes the partial tmpfile.
+func WithMaxSize(n int64) InstallerOption {
+	return func(r *RealInstaller) {
+		if n > 0 {
+			r.maxSize = n
+		}
+	}
+}
+
+// WithInstallerStatePath overrides the state-file location. Tests pass
+// temp-dir paths so nothing leaks into the user's config dir.
+func WithInstallerStatePath(p string) InstallerOption {
+	return func(r *RealInstaller) { r.statePath = p }
+}
+
+// withFreeBytesFunc is a test-only seam for injecting a fake statfs without
+// introducing a package-level mutable. Not exported.
+func withFreeBytesFunc(fn func(dir string) (int64, error)) InstallerOption {
+	return func(r *RealInstaller) { r.freeBytes = fn }
+}
+
+// WithStateUpdater injects the plugin's serialised read-modify-write helper.
+// Install/Rollback use it to mutate only PendingRestartVersion and
+// PrevBinaryPath without clobbering fields the checker owns (LastChecked,
+// LastSeenVersion) or the user owns (Channel). When nil, Install/Rollback
+// fall back to a local LoadState/SaveState round-trip that is *not*
+// serialised against concurrent checker ticks.
+func WithStateUpdater(fn func(func(*State)) error) InstallerOption {
+	return func(r *RealInstaller) { r.updateStateF = fn }
+}
+
+// WithMaxArchiveBytes caps the total decompressed bytes extract() will
+// tolerate across every tar entry. Prevents a highly compressible archive
+// from forcing gigabytes of decompression work.
+func WithMaxArchiveBytes(n int64) InstallerOption {
+	return func(r *RealInstaller) {
+		if n > 0 {
+			r.maxArchive = n
+		}
+	}
+}
+
+// WithMaxArchiveEntries caps the number of tar headers extract() will
+// accept. Complementary to WithMaxArchiveBytes for archives with many
+// empty entries.
+func WithMaxArchiveEntries(n int) InstallerOption {
+	return func(r *RealInstaller) {
+		if n > 0 {
+			r.maxEntries = n
+		}
+	}
+}
+
+// NewInstaller returns a RealInstaller with sensible defaults. Callers may
+// override any seam via Options. A nil return is never produced.
+func NewInstaller(opts ...InstallerOption) *RealInstaller {
+	r := &RealInstaller{
+		executable: os.Executable,
+		goos:       runtime.GOOS,
+		goarch:     runtime.GOARCH,
+		client:     &http.Client{Timeout: defaultInstallHTTPTimeout},
+		maxSize:    defaultMaxAssetBytes,
+		maxArchive: defaultMaxArchiveBytes,
+		maxEntries: defaultMaxArchiveEntries,
+		freeBytes:  freeBytes,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// Install implements Installer.Install. See the package-level design notes
+// in autoupdate.go and the Install flow in docs/autoupdate.md (if present).
+// On Windows this returns nil after posting a notify-only fallback.
+func (r *RealInstaller) Install(ctx context.Context, host *plugin.Host, rel Release, cur string) error {
+	_ = cur // retained for symmetry with Installer interface; surfaced via status text only.
+
+	exe, asset, checksums, err := r.preflight(rel)
+	if err != nil {
+		if errors.Is(err, errPreflightWindows) {
+			r.postWindowsNotice(host, rel)
+			return nil
+		}
+		r.postError(host, err.Error())
+		return err
+	}
+
+	r.postStatus(host, "⬇ downloading "+NormalizeVersion(rel.TagName), "yellow")
+
+	parent := filepath.Dir(exe)
+
+	// 1. Download the archive to a sibling tmpfile and compute its SHA-256.
+	archiveTmp, sum, archiveSize, err := r.downloadArchive(ctx, asset, parent)
+	if err != nil {
+		r.postError(host, err.Error())
+		return err
+	}
+	defer func() {
+		// best-effort: archiveTmp is cleaned up once the binary is extracted;
+		// this remove is the safety net on error paths that return before the
+		// explicit remove below.
+		if archiveTmp != "" {
+			_ = os.Remove(archiveTmp)
+		}
+	}()
+	_ = archiveSize // intentionally unused — we verify against Content-Length in download
+
+	// 2. Fetch checksums.txt, find our asset's line, verify.
+	if err := r.verifyChecksum(ctx, checksums, asset.Name, sum); err != nil {
+		r.postError(host, err.Error())
+		return err
+	}
+
+	// 3. Extract the single binary into a sibling tmpfile and chmod 0o755.
+	binaryTmp, err := r.extractBinary(archiveTmp, asset.Name, parent)
+	if err != nil {
+		r.postError(host, err.Error())
+		return err
+	}
+
+	// Archive is no longer needed.
+	_ = os.Remove(archiveTmp)
+	archiveTmp = "" // disarm the deferred cleanup above.
+
+	// 4. Atomic swap: exe -> exe.prev, binaryTmp -> exe.
+	prev := exe + ".prev"
+	if err := os.Rename(exe, prev); err != nil {
+		_ = os.Remove(binaryTmp)
+		wrapped := fmt.Errorf("autoupdate: backup current binary: %w", err)
+		r.postError(host, wrapped.Error())
+		return wrapped
+	}
+	if err := os.Rename(binaryTmp, exe); err != nil {
+		// Try to restore the previous binary so the editor keeps running.
+		restoreErr := os.Rename(prev, exe)
+		_ = os.Remove(binaryTmp)
+		wrapped := fmt.Errorf("autoupdate: swap new binary into place: %w", err)
+		if restoreErr != nil {
+			wrapped = fmt.Errorf("%w (restore also failed: %v)", wrapped, restoreErr)
+		}
+		r.postError(host, wrapped.Error())
+		return wrapped
+	}
+
+	// 5. Persist pending-restart state so Rollback and status-bar rendering
+	// know what's in flight. We mutate only the two fields we own so a
+	// concurrent checker tick's LastChecked/LastSeenVersion writes are not
+	// clobbered.
+	if err := r.mutateState(func(s *State) {
+		s.PendingRestartVersion = rel.TagName
+		s.PrevBinaryPath = prev
+	}); err != nil {
+		// State is advisory; we've already swapped binaries successfully.
+		// Surface via notify but do not unwind.
+		r.postError(host, "autoupdate: save state: "+err.Error())
+	}
+
+	r.postStatus(host, "⟳ restart to apply "+NormalizeVersion(rel.TagName), "yellow")
+	if host != nil {
+		_ = host.PostNotif("autoupdate", "ui/notify", map[string]string{
+			"level":   "info",
+			"message": "update installed — restart nistru to apply",
+		})
+	}
+	return nil
+}
+
+// Rollback implements Installer.Rollback. It moves the ".prev" sibling back
+// over the current binary, clears state, and notifies the user to restart.
+func (r *RealInstaller) Rollback(_ context.Context, host *plugin.Host) error {
+	prev := r.readPrevBinaryPath()
+	if prev == "" || !fileExists(prev) {
+		if host != nil {
+			_ = host.PostNotif("autoupdate", "ui/notify", map[string]string{
+				"level":   "warn",
+				"message": "autoupdate: no previous binary to roll back to",
+			})
+		}
+		return nil
+	}
+
+	exe, err := r.resolveExecutable()
+	if err != nil {
+		r.postError(host, err.Error())
+		return err
+	}
+
+	if err := os.Rename(prev, exe); err != nil {
+		wrapped := fmt.Errorf("autoupdate: restore previous binary: %w", err)
+		r.postError(host, wrapped.Error())
+		return wrapped
+	}
+
+	if err := r.mutateState(func(s *State) {
+		s.PendingRestartVersion = ""
+		s.PrevBinaryPath = ""
+	}); err != nil {
+		r.postError(host, "autoupdate: save state: "+err.Error())
+	}
+
+	r.postStatus(host, "", "")
+	if host != nil {
+		_ = host.PostNotif("autoupdate", "ui/notify", map[string]string{
+			"level":   "info",
+			"message": "rolled back — restart nistru to use the previous version",
+		})
+	}
+	return nil
+}
+
+// readPrevBinaryPath returns the persisted PrevBinaryPath, using whichever
+// seam is wired: the plugin's serialised updater (production path) or a
+// direct LoadState (stand-alone installer tests). The updater case uses a
+// no-op mutation so the path is read under the same mutex that writers use.
+func (r *RealInstaller) readPrevBinaryPath() string {
+	if r.updateStateF != nil {
+		var out string
+		_ = r.updateStateF(func(s *State) { out = s.PrevBinaryPath })
+		return out
+	}
+	if r.statePath == "" {
+		return ""
+	}
+	st, _ := LoadState(r.statePath)
+	return st.PrevBinaryPath
+}
+
+// mutateState applies mut to the persisted state. When the installer has
+// been wired with WithStateUpdater (production plugin path), the mutation
+// flows through the plugin's serialised helper. Otherwise (stand-alone
+// installer tests), it falls back to a local LoadState+SaveState which
+// races against concurrent writers — this is only safe because those
+// tests never run a checker concurrently.
+func (r *RealInstaller) mutateState(mut func(*State)) error {
+	if r.updateStateF != nil {
+		return r.updateStateF(mut)
+	}
+	if r.statePath == "" {
+		return nil
+	}
+	st, _ := LoadState(r.statePath)
+	mut(&st)
+	return SaveState(r.statePath, st)
+}
+
+// Cleanup deletes the .prev sibling when PendingRestartVersion has been
+// cleared (e.g. the user restarted into the new binary). The plugin calls
+// this on Shutdown via an interface assertion. Reads state via whichever
+// seam is wired — prefers the plugin's serialised updater when present
+// (production path), falls back to a direct LoadState (stand-alone tests).
+func (r *RealInstaller) Cleanup(_ context.Context) error {
+	var st State
+	if r.updateStateF != nil {
+		// Snapshot via a no-op mutation so we observe state under the
+		// plugin's mutex without racing against a concurrent writer.
+		_ = r.updateStateF(func(s *State) { st = *s })
+	} else if r.statePath != "" {
+		var err error
+		if st, err = LoadState(r.statePath); err != nil {
+			return nil // best-effort; forward-compat failures never block shutdown.
+		}
+	} else {
+		return nil
+	}
+	if st.PendingRestartVersion != "" {
+		// User has not yet restarted — keep the .prev so they can roll back.
+		return nil
+	}
+	exe, err := r.resolveExecutable()
+	if err != nil {
+		return nil
+	}
+	prev := exe + ".prev"
+	if fileExists(prev) {
+		_ = os.Remove(prev)
+	}
+	return nil
+}
+
+// preflight validates everything Install needs before it starts touching
+// the filesystem in earnest. Returns the resolved executable path plus the
+// chosen binary / checksums Assets.
+func (r *RealInstaller) preflight(rel Release) (string, Asset, Asset, error) {
+	// Windows: bail out with the sentinel; Install renders the notify.
+	if r.goos == "windows" {
+		return "", Asset{}, Asset{}, errPreflightWindows
+	}
+
+	exe, err := r.resolveExecutable()
+	if err != nil {
+		return "", Asset{}, Asset{}, err
+	}
+
+	parent := filepath.Dir(exe)
+	info, err := os.Stat(parent)
+	if err != nil {
+		return "", Asset{}, Asset{}, fmt.Errorf("autoupdate: stat parent dir: %w", err)
+	}
+	if !info.IsDir() {
+		return "", Asset{}, Asset{}, fmt.Errorf("autoupdate: parent %q is not a directory", parent)
+	}
+	// Writability probe — creating and immediately removing a temp file is
+	// the most portable test; permission errors surface here.
+	probe, err := os.CreateTemp(parent, ".nistru-preflight-*")
+	if err != nil {
+		return "", Asset{}, Asset{}, fmt.Errorf("autoupdate: parent dir not writable: %w", err)
+	}
+	_ = probe.Close()
+	_ = os.Remove(probe.Name())
+
+	bin, cs, err := AssetMatch(rel, r.goos, r.goarch)
+	if err != nil {
+		return "", Asset{}, Asset{}, err
+	}
+	if cs.Name == "" {
+		return "", Asset{}, Asset{}, errors.New("autoupdate: release has no checksums.txt; refusing to install")
+	}
+
+	// Disk space: require >= 2× asset.Size free. Fall back to permissive
+	// behavior if the probe cannot answer.
+	if r.freeBytes != nil && bin.Size > 0 {
+		avail, ferr := r.freeBytes(parent)
+		if ferr == nil && avail < 2*bin.Size {
+			return "", Asset{}, Asset{}, fmt.Errorf(
+				"autoupdate: insufficient free space in %q: need %d bytes, have %d",
+				parent, 2*bin.Size, avail,
+			)
+		}
+	}
+
+	return exe, bin, cs, nil
+}
+
+// resolveExecutable resolves the running binary path and its symlink
+// target. This matters when nistru is installed via `go install` which
+// drops a symlink under $GOPATH/bin; we want to replace the real file.
+func (r *RealInstaller) resolveExecutable() (string, error) {
+	raw, err := r.executable()
+	if err != nil {
+		return "", fmt.Errorf("autoupdate: locate running binary: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(raw)
+	if err != nil {
+		return "", fmt.Errorf("autoupdate: resolve binary symlink %q: %w", raw, err)
+	}
+	return resolved, nil
+}
+
+// downloadArchive streams the asset into a tmpfile in parent and computes
+// its SHA-256 in-flight. Returns the tmpfile path, the hex digest, and the
+// number of bytes copied. The tmpfile is removed on any error.
+func (r *RealInstaller) downloadArchive(ctx context.Context, asset Asset, parent string) (string, string, int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, asset.BrowserDownloadURL, nil)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("autoupdate: build download request: %w", err)
+	}
+	req.Header.Set("User-Agent", "nistru-autoupdate")
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("autoupdate: download asset: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", "", 0, fmt.Errorf("autoupdate: download asset: http %d", resp.StatusCode)
+	}
+
+	f, err := os.CreateTemp(parent, "nistru-download-*")
+	if err != nil {
+		return "", "", 0, fmt.Errorf("autoupdate: create download tmp: %w", err)
+	}
+	tmp := f.Name()
+	cleanup := func() {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+	}
+
+	h := sha256.New()
+	limited := io.LimitReader(resp.Body, r.maxSize+1)
+	w := io.MultiWriter(f, h)
+	n, err := io.Copy(w, limited)
+	if err != nil {
+		cleanup()
+		return "", "", 0, fmt.Errorf("autoupdate: copy asset: %w", err)
+	}
+	if n > r.maxSize {
+		cleanup()
+		return "", "", 0, fmt.Errorf("autoupdate: asset exceeds max size of %d bytes", r.maxSize)
+	}
+	// Content-Length sanity check: if present and positive, assert we got
+	// all the bytes the server promised.
+	if cl := resp.ContentLength; cl > 0 && n != cl {
+		cleanup()
+		return "", "", 0, fmt.Errorf("autoupdate: truncated download: got %d of %d bytes", n, cl)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return "", "", 0, fmt.Errorf("autoupdate: close download tmp: %w", err)
+	}
+	return tmp, hex.EncodeToString(h.Sum(nil)), n, nil
+}
+
+// verifyChecksum fetches checksums.txt, finds the line for assetName, and
+// confirms it matches sum. checksums.txt format:
+//
+//	<hex sha256>  <filename>
+//
+// (two spaces between fields is conventional; one space is also accepted).
+func (r *RealInstaller) verifyChecksum(ctx context.Context, checksums Asset, assetName, sum string) error {
+	if checksums.BrowserDownloadURL == "" {
+		return errors.New("autoupdate: release has no checksums.txt")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checksums.BrowserDownloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("autoupdate: build checksums request: %w", err)
+	}
+	req.Header.Set("User-Agent", "nistru-autoupdate")
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("autoupdate: download checksums: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("autoupdate: download checksums: http %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxChecksumsBodyBytes))
+	if err != nil {
+		return fmt.Errorf("autoupdate: read checksums: %w", err)
+	}
+
+	expected, ok := findChecksum(body, assetName)
+	if !ok {
+		return fmt.Errorf("autoupdate: checksums.txt has no entry for %q", assetName)
+	}
+	if !strings.EqualFold(expected, sum) {
+		return fmt.Errorf("autoupdate: checksum mismatch for %q: expected %s, got %s", assetName, expected, sum)
+	}
+	return nil
+}
+
+// findChecksum scans a checksums.txt body and returns the hex digest
+// associated with name, or "" if not present.
+func findChecksum(body []byte, name string) (string, bool) {
+	for line := range strings.SplitSeq(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// First field is the digest; last field is the filename.
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		fname := fields[len(fields)-1]
+		// Some generators emit "*<name>" with a binary-mode marker.
+		fname = strings.TrimPrefix(fname, "*")
+		if fname == name {
+			return fields[0], true
+		}
+	}
+	return "", false
+}
+
+// extractBinary walks a gzip-tar archive and writes the single executable
+// entry to a sibling tmpfile in parent. The extracted file is chmodded 0o755.
+//
+// Rejections:
+//   - any entry whose name contains "..".
+//   - any regular-file entry larger than r.maxSize.
+//   - archives containing more than one plausible binary (see isLikelyBinary).
+//   - archives containing no binary entry at all.
+//
+// assetName is the archive's own filename, used only for the error text.
+func (r *RealInstaller) extractBinary(archivePath, assetName, parent string) (string, error) {
+	_ = assetName
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("autoupdate: open archive: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", fmt.Errorf("autoupdate: gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	// Cap total decompressed bytes so a tar bomb (gigabytes of zeros
+	// compressed into kilobytes) cannot exhaust CPU/disk. The +1 lets us
+	// distinguish "exactly at limit" from "overflow" with one extra byte.
+	maxArchive := r.maxArchive
+	if maxArchive <= 0 {
+		maxArchive = defaultMaxArchiveBytes
+	}
+	maxEntries := r.maxEntries
+	if maxEntries <= 0 {
+		maxEntries = defaultMaxArchiveEntries
+	}
+	limited := &io.LimitedReader{R: gz, N: maxArchive + 1}
+	tr := tar.NewReader(limited)
+
+	out, err := os.CreateTemp(parent, "nistru-extract-*")
+	if err != nil {
+		return "", fmt.Errorf("autoupdate: create extract tmp: %w", err)
+	}
+	outPath := out.Name()
+	cleanup := func() {
+		_ = out.Close()
+		_ = os.Remove(outPath)
+	}
+
+	var (
+		found      bool
+		foundCount int
+		entryCount int
+	)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			cleanup()
+			return "", fmt.Errorf("autoupdate: read tar: %w", err)
+		}
+		entryCount++
+		if entryCount > maxEntries {
+			cleanup()
+			return "", fmt.Errorf("autoupdate: archive exceeds max entry count of %d", maxEntries)
+		}
+		// Path-traversal guard: reject any entry whose name contains "..".
+		if strings.Contains(hdr.Name, "..") {
+			cleanup()
+			return "", fmt.Errorf("autoupdate: rejected path-traversal entry %q", hdr.Name)
+		}
+		// Archive-bomb guard: any single entry whose declared size alone
+		// would blow past the whole-archive cap is rejected before we
+		// attempt to read it.
+		if hdr.Size > maxArchive {
+			cleanup()
+			return "", fmt.Errorf("autoupdate: archive entry %q exceeds max decompressed size of %d bytes", hdr.Name, maxArchive)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if hdr.Size > r.maxSize {
+			cleanup()
+			return "", fmt.Errorf("autoupdate: archive entry %q exceeds max size", hdr.Name)
+		}
+		if !isLikelyBinary(hdr.Name) {
+			continue
+		}
+		foundCount++
+		if foundCount > 1 {
+			cleanup()
+			return "", errors.New("autoupdate: archive contains multiple candidate binaries")
+		}
+		if _, err := io.Copy(out, io.LimitReader(tr, r.maxSize+1)); err != nil {
+			cleanup()
+			return "", fmt.Errorf("autoupdate: extract binary: %w", err)
+		}
+		found = true
+	}
+	if limited.N <= 0 {
+		// tar.Reader read past our budget.
+		cleanup()
+		return "", fmt.Errorf("autoupdate: archive exceeds max decompressed size of %d bytes", maxArchive)
+	}
+
+	if !found {
+		cleanup()
+		return "", errors.New("autoupdate: archive contains no nistru binary")
+	}
+	if err := out.Chmod(0o755); err != nil {
+		cleanup()
+		return "", fmt.Errorf("autoupdate: chmod extracted binary: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(outPath)
+		return "", fmt.Errorf("autoupdate: close extracted binary: %w", err)
+	}
+	return outPath, nil
+}
+
+// isLikelyBinary returns true if the tar entry looks like the nistru
+// executable. Only the basename is considered so archives that place the
+// binary under a versioned dir (e.g. "nistru_v0.2.0_linux_amd64/nistru")
+// still match. Anything else is ignored rather than rejected, so bundled
+// README/LICENSE files don't trip the "multiple binaries" rule.
+func isLikelyBinary(name string) bool {
+	base := filepath.Base(name)
+	return base == "nistru" || base == "nistru.exe"
+}
+
+// postStatus emits a statusBar/set notif. Empty text clears the segment.
+func (r *RealInstaller) postStatus(host *plugin.Host, text, color string) {
+	if host == nil {
+		return
+	}
+	_ = host.PostNotif("autoupdate", "statusBar/set", map[string]string{
+		"segment": "autoupdate",
+		"text":    text,
+		"color":   color,
+	})
+}
+
+// postError surfaces err as an error-level ui/notify. A twin of the helper
+// in autoupdate.go; kept here so install.go stays self-contained.
+func (r *RealInstaller) postError(host *plugin.Host, msg string) {
+	if host == nil {
+		return
+	}
+	_ = host.PostNotif("autoupdate", "ui/notify", map[string]string{
+		"level":   "error",
+		"message": msg,
+	})
+}
+
+// postWindowsNotice surfaces the notify-only fallback for Windows users.
+// It does not touch the filesystem.
+func (r *RealInstaller) postWindowsNotice(host *plugin.Host, rel Release) {
+	if host == nil {
+		return
+	}
+	tag := rel.TagName
+	if tag == "" {
+		tag = "latest"
+	}
+	cmd := fmt.Sprintf("go install github.com/savimcio/nistru/cmd/nistru@%s", tag)
+	_ = host.PostNotif("autoupdate", "ui/notify", map[string]string{
+		"level":   "warn",
+		"message": "autoupdate: in-place install is not supported on Windows. Run: " + cmd,
+	})
+	_ = host.PostNotif("autoupdate", "statusBar/set", map[string]string{
+		"segment": "autoupdate",
+		"text":    "Run: " + cmd,
+		"color":   "yellow",
+	})
+}
+
+// fileExists is a small helper that returns true iff path resolves to a
+// file the current user can stat. Errors (including permission denied)
+// conservatively map to false so Rollback short-circuits cleanly.
+func fileExists(path string) bool {
+	_, err := os.Lstat(path)
+	return err == nil
+}
+
+// Compile-time assertion that RealInstaller satisfies Installer.
+var _ Installer = (*RealInstaller)(nil)

--- a/internal/plugins/autoupdate/install_posix.go
+++ b/internal/plugins/autoupdate/install_posix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package autoupdate
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// freeBytes returns the number of bytes available to the caller on the
+// filesystem containing dir. It uses statfs(2) from the stdlib.
+//
+// Build-tagged: Windows has no statfs; install_windows.go provides a stub.
+func freeBytes(dir string) (int64, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(dir, &st); err != nil {
+		return 0, fmt.Errorf("statfs %q: %w", dir, err)
+	}
+	// Bavail and Bsize are unsigned but small enough in practice; cap at
+	// math.MaxInt64 implicitly via int64 conversion. If the multiplication
+	// ever overflows on a 32-bit build, returning a value that still passes
+	// the threshold is the safe outcome.
+	return int64(st.Bavail) * int64(st.Bsize), nil
+}

--- a/internal/plugins/autoupdate/install_test.go
+++ b/internal/plugins/autoupdate/install_test.go
@@ -1,0 +1,1194 @@
+package autoupdate
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/savimcio/nistru/plugin"
+)
+
+// -----------------------------------------------------------------------------
+// Scaffolding — kept local to install_test.go so the other tests in the
+// package are unaffected.
+
+// dummyExeContents is the byte pattern written to the "current binary" in
+// every test before Install runs. Short-circuits confusion between "the old
+// binary is in place" and "an empty file is in place".
+var dummyExeContents = []byte("#!/bin/sh\necho OLD NISTRU\n")
+
+// newInstallerSetup creates a temp dir, writes a dummy executable into it,
+// and returns the dir and the exe path. The defensive check at the start
+// enforces the "never touch real paths" rule from the task spec.
+func newInstallerSetup(t *testing.T) (dir, exePath string) {
+	t.Helper()
+	dir = t.TempDir()
+	exePath = filepath.Join(dir, "nistru")
+	if err := os.WriteFile(exePath, dummyExeContents, 0o755); err != nil {
+		t.Fatalf("seed dummy exe: %v", err)
+	}
+
+	// Defensive: explode immediately if dir is somehow under a real install
+	// location. t.TempDir() returns under $TMPDIR, never under $GOPATH/bin;
+	// this belt-and-braces check is cheap.
+	for _, forbidden := range []string{"/nistru/bin/", "/.go/bin/", "/gopath/bin/"} {
+		if strings.Contains(exePath, forbidden) {
+			t.Fatalf("test exe path %q is under forbidden location %q", exePath, forbidden)
+		}
+	}
+	return dir, exePath
+}
+
+// makeTarGz builds an in-memory gzipped tarball from entries. Each entry's
+// Typeflag defaults to tar.TypeReg.
+func makeTarGz(t *testing.T, entries []tarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, e := range entries {
+		hdr := &tar.Header{
+			Name:     e.Name,
+			Mode:     0o755,
+			Size:     int64(len(e.Body)),
+			Typeflag: tar.TypeReg,
+		}
+		if e.Typeflag != 0 {
+			hdr.Typeflag = e.Typeflag
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader %q: %v", e.Name, err)
+		}
+		if _, err := tw.Write(e.Body); err != nil {
+			t.Fatalf("Write %q: %v", e.Name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tw.Close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gz.Close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+type tarEntry struct {
+	Name     string
+	Body     []byte
+	Typeflag byte
+}
+
+// sha256Hex returns the hex digest of data.
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// releaseFixture bundles the Release JSON + archive bytes + checksums body
+// the test needs to drive Install end-to-end.
+type releaseFixture struct {
+	Release       Release
+	ArchiveName   string
+	ArchiveBytes  []byte
+	ChecksumsBody string
+	newBinary     []byte
+}
+
+// defaultFixture returns a release with a single valid binary asset + a
+// correct checksums.txt. Callers may mutate fields before starting the
+// server.
+func defaultFixture(t *testing.T) *releaseFixture {
+	t.Helper()
+	newBin := []byte("NEW NISTRU BINARY")
+	archive := makeTarGz(t, []tarEntry{{Name: "nistru", Body: newBin}})
+	name := "nistru_v99.0.0_darwin_arm64.tar.gz"
+	checksums := fmt.Sprintf("%s  %s\n", sha256Hex(archive), name)
+
+	return &releaseFixture{
+		Release: Release{
+			TagName: "v99.0.0",
+			Name:    "99.0.0",
+			Assets: []Asset{
+				{Name: name, Size: int64(len(archive))},
+				{Name: "checksums.txt", Size: int64(len(checksums))},
+			},
+		},
+		ArchiveName:   name,
+		ArchiveBytes:  archive,
+		ChecksumsBody: checksums,
+		newBinary:     newBin,
+	}
+}
+
+// startAssetServer wires an httptest.Server that serves:
+//
+//	GET /{ArchiveName}   -> archive bytes
+//	GET /checksums.txt   -> checksums body
+//
+// The fixture's Asset URLs are updated in place so AssetMatch returns the
+// server-local URLs.
+func startAssetServer(t *testing.T, fx *releaseFixture) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + fx.ArchiveName:
+			w.Header().Set("Content-Type", "application/gzip")
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(fx.ArchiveBytes)))
+			_, _ = w.Write(fx.ArchiveBytes)
+		case "/checksums.txt":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte(fx.ChecksumsBody))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	// Rewire asset URLs to point at the server.
+	for i := range fx.Release.Assets {
+		fx.Release.Assets[i].BrowserDownloadURL = srv.URL + "/" + fx.Release.Assets[i].Name
+	}
+	return srv
+}
+
+// newTestInstaller builds a RealInstaller pointed at a fake executable in
+// dir + a state file in dir, with GOOS/GOARCH defaulting to darwin/arm64.
+func newTestInstaller(t *testing.T, dir, exePath string, opts ...InstallerOption) *RealInstaller {
+	t.Helper()
+	statePath := filepath.Join(dir, "state.json")
+	base := []InstallerOption{
+		WithExecutableFunc(func() (string, error) { return exePath, nil }),
+		WithGoos("darwin"),
+		WithGoarch("arm64"),
+		WithInstallerStatePath(statePath),
+		WithInstallerHTTPClient(&http.Client{Timeout: 5 * time.Second}),
+		// Default: plenty of free space.
+		withFreeBytesFunc(func(string) (int64, error) { return math.MaxInt64, nil }),
+	}
+	base = append(base, opts...)
+	return NewInstaller(base...)
+}
+
+// readFile is a tiny helper that wraps os.ReadFile with t.Fatalf on error.
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %q: %v", path, err)
+	}
+	return b
+}
+
+// -----------------------------------------------------------------------------
+// Host recorder. Install/Rollback use *plugin.Host to PostNotif status and
+// errors; we set up a real host (with no registered plugins) and drain its
+// inbound channel into a thread-safe slice the tests assert on.
+
+type recordedNotif struct {
+	Method  string
+	Payload map[string]string
+}
+
+type hostRecorder struct {
+	host *plugin.Host
+	mu   sync.Mutex
+	msgs []recordedNotif
+}
+
+// newHostRecorder constructs a plugin.Host with no registered plugins and
+// returns it together with a recorder. The recorder is populated on demand
+// (via drain()) rather than from a background goroutine — Host has no
+// public seam for closing its inbound channel, so a background drain would
+// leak. Tests call drain() before asserting on the recorder.
+func newHostRecorder(t *testing.T) (*plugin.Host, *hostRecorder) {
+	t.Helper()
+	reg := plugin.NewRegistry()
+	h := plugin.NewHost(reg)
+	if err := h.Start(""); err != nil {
+		t.Fatalf("host.Start: %v", err)
+	}
+	rec := &hostRecorder{host: h}
+	t.Cleanup(func() {
+		// Shutdown is a no-op without registered plugins, but we still call
+		// it so the host leaves no lingering resources. There is no goroutine
+		// to join.
+		_ = h.Shutdown(100 * time.Millisecond)
+	})
+	return h, rec
+}
+
+// drain pulls every currently-buffered message off the host's inbound
+// channel using a short-timeout Recv() loop. The inbound channel is
+// non-blocking from PostNotif's side (drop-on-full), so once Install/
+// Rollback has returned, every notification we care about is already in
+// the buffer.
+func (r *hostRecorder) drain(maxWait time.Duration) {
+	deadline := time.Now().Add(maxWait)
+	for time.Now().Before(deadline) {
+		msg, ok := recvWithTimeout(r.host, 20*time.Millisecond)
+		if !ok {
+			return
+		}
+		n, ok := msg.(plugin.PluginNotifMsg)
+		if !ok {
+			continue
+		}
+		payload := map[string]string{}
+		_ = json.Unmarshal(n.Params, &payload)
+		r.mu.Lock()
+		r.msgs = append(r.msgs, recordedNotif{Method: n.Method, Payload: payload})
+		r.mu.Unlock()
+	}
+}
+
+// recvWithTimeout pulls one message from h.Recv() with a deadline. Since
+// h.Recv() returns a blocking tea.Cmd, we invoke it in a goroutine and
+// race it against a timer. The goroutine that wins picks up the value
+// from the channel; we return false on timeout.
+//
+// This helper may leak a goroutine per timeout, which is acceptable for
+// test lifetimes (the host's inbound channel has drop-on-full semantics,
+// so a blocked Recv does no harm beyond the stranded goroutine).
+func recvWithTimeout(h *plugin.Host, timeout time.Duration) (any, bool) {
+	out := make(chan any, 1)
+	go func() {
+		if cmd := h.Recv(); cmd != nil {
+			if v := cmd(); v != nil {
+				out <- v
+			}
+		}
+		close(out)
+	}()
+	select {
+	case v, ok := <-out:
+		if !ok {
+			return nil, false
+		}
+		return v, true
+	case <-time.After(timeout):
+		return nil, false
+	}
+}
+
+// snapshot returns a copy of the messages recorded so far.
+func (r *hostRecorder) snapshot() []recordedNotif {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedNotif, len(r.msgs))
+	copy(out, r.msgs)
+	return out
+}
+
+// waitFor drains up to timeout and returns true iff any recorded notif
+// satisfies pred at any point during the drain.
+func (r *hostRecorder) waitFor(timeout time.Duration, pred func(recordedNotif) bool) bool {
+	r.drain(timeout)
+	return slices.ContainsFunc(r.snapshot(), pred)
+}
+
+// -----------------------------------------------------------------------------
+// Preflight tests.
+
+func TestPreflightAllGood(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	r := newTestInstaller(t, dir, exePath)
+	gotExe, bin, cs, err := r.preflight(fx.Release)
+	if err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+	want, _ := filepath.EvalSymlinks(exePath)
+	if gotExe != want {
+		t.Fatalf("preflight exe = %q, want %q", gotExe, want)
+	}
+	if bin.Name != fx.ArchiveName {
+		t.Fatalf("binary = %q, want %q", bin.Name, fx.ArchiveName)
+	}
+	if cs.Name != "checksums.txt" {
+		t.Fatalf("checksums = %q, want checksums.txt", cs.Name)
+	}
+}
+
+func TestPreflightUnwritableDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores POSIX permissions; test relies on EACCES")
+	}
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod ro: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	r := newTestInstaller(t, dir, exePath)
+	_, _, _, err := r.preflight(fx.Release)
+	if err == nil || !strings.Contains(err.Error(), "not writable") {
+		t.Fatalf("preflight err = %v, want 'not writable'", err)
+	}
+}
+
+func TestPreflightNoAssetForPlatform(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	r := newTestInstaller(t, dir, exePath, WithGoos("linux"), WithGoarch("s390x"))
+	_, _, _, err := r.preflight(fx.Release)
+	if !errors.Is(err, ErrNoAssetForPlatform) {
+		t.Fatalf("preflight err = %v, want ErrNoAssetForPlatform", err)
+	}
+}
+
+func TestPreflightMissingChecksums(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+	// Drop the checksums asset.
+	fx.Release.Assets = fx.Release.Assets[:1]
+
+	r := newTestInstaller(t, dir, exePath)
+	_, _, _, err := r.preflight(fx.Release)
+	if err == nil || !strings.Contains(err.Error(), "checksums") {
+		t.Fatalf("preflight err = %v, want 'checksums' error", err)
+	}
+}
+
+func TestPreflightInsufficientSpace(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+	// Bump asset.Size so 2× > our fake free space.
+	fx.Release.Assets[0].Size = 10 * 1024
+
+	r := newTestInstaller(t, dir, exePath,
+		withFreeBytesFunc(func(string) (int64, error) { return 1024, nil }),
+	)
+	_, _, _, err := r.preflight(fx.Release)
+	if err == nil || !strings.Contains(err.Error(), "insufficient free space") {
+		t.Fatalf("preflight err = %v, want 'insufficient free space'", err)
+	}
+}
+
+func TestPreflightWindowsSkipsSwap(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	host, rec := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath, WithGoos("windows"))
+
+	if err := r.Install(context.Background(), host, fx.Release, "v0.1.0"); err != nil {
+		t.Fatalf("Install on windows returned err=%v, want nil (notify-only)", err)
+	}
+
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe was modified on windows path; got %q", got)
+	}
+	if _, err := os.Stat(exePath + ".prev"); err == nil {
+		t.Fatalf(".prev file exists on windows path")
+	}
+	want := "go install github.com/savimcio/nistru/cmd/nistru@v99.0.0"
+	if !rec.waitFor(500*time.Millisecond, func(m recordedNotif) bool {
+		return m.Method == "ui/notify" && strings.Contains(m.Payload["message"], want)
+	}) {
+		t.Fatalf("no ui/notify with %q in inbox: %+v", want, rec.snapshot())
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Install tests.
+
+func TestInstallHappyPath(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+	_ = startAssetServer(t, fx)
+
+	host, rec := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath)
+
+	if err := r.Install(context.Background(), host, fx.Release, "v0.1.0"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	// Assertions use the resolved path — macOS maps /var -> /private/var, so
+	// the installer's EvalSymlinks-normalized path may differ from the raw
+	// t.TempDir() path we seeded with.
+	resolvedExe, err := filepath.EvalSymlinks(exePath)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(exe): %v", err)
+	}
+	if got := readFile(t, resolvedExe); !bytes.Equal(got, fx.newBinary) {
+		t.Fatalf("exe contents = %q, want %q", got, fx.newBinary)
+	}
+	prev := resolvedExe + ".prev"
+	if got := readFile(t, prev); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("prev contents = %q, want old dummy contents", got)
+	}
+	st, err := LoadState(filepath.Join(dir, "state.json"))
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if st.PendingRestartVersion != "v99.0.0" {
+		t.Fatalf("state.PendingRestartVersion = %q, want v99.0.0", st.PendingRestartVersion)
+	}
+	if st.PrevBinaryPath != prev {
+		t.Fatalf("state.PrevBinaryPath = %q, want %q", st.PrevBinaryPath, prev)
+	}
+	if !rec.waitFor(500*time.Millisecond, func(m recordedNotif) bool {
+		return m.Method == "statusBar/set" && strings.Contains(m.Payload["text"], "restart to apply")
+	}) {
+		t.Fatalf("expected statusBar/set restart message: %+v", rec.snapshot())
+	}
+	if !rec.waitFor(500*time.Millisecond, func(m recordedNotif) bool {
+		return m.Method == "ui/notify" && m.Payload["level"] == "info" &&
+			strings.Contains(m.Payload["message"], "update installed")
+	}) {
+		t.Fatalf("expected info notify 'update installed': %+v", rec.snapshot())
+	}
+}
+
+func TestInstallWrongChecksum(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+	fx.ChecksumsBody = "deadbeef" + strings.Repeat("0", 56) + "  " + fx.ArchiveName + "\n"
+	_ = startAssetServer(t, fx)
+
+	host, _ := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath)
+
+	err := r.Install(context.Background(), host, fx.Release, "v0.1.0")
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("Install err = %v, want checksum mismatch", err)
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe was modified on checksum failure: %q", got)
+	}
+	if _, err := os.Stat(exePath + ".prev"); err == nil {
+		t.Fatalf(".prev file exists despite checksum failure")
+	}
+	st, _ := LoadState(filepath.Join(dir, "state.json"))
+	if st.PendingRestartVersion != "" || st.PrevBinaryPath != "" {
+		t.Fatalf("state mutated on failure: %+v", st)
+	}
+}
+
+func TestInstallOversizedAsset(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	bigBin := bytes.Repeat([]byte{0x42}, 2*1024*1024)
+	fx.ArchiveBytes = makeTarGz(t, []tarEntry{{Name: "nistru", Body: bigBin}})
+	fx.Release.Assets[0].Size = int64(len(fx.ArchiveBytes))
+	fx.ChecksumsBody = fmt.Sprintf("%s  %s\n", sha256Hex(fx.ArchiveBytes), fx.ArchiveName)
+	_ = startAssetServer(t, fx)
+
+	host, _ := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath,
+		WithMaxSize(1024*1024),
+	)
+
+	err := r.Install(context.Background(), host, fx.Release, "v0.1.0")
+	if err == nil || !strings.Contains(err.Error(), "exceeds max size") {
+		t.Fatalf("Install err = %v, want 'exceeds max size'", err)
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe was modified on oversize failure: %q", got)
+	}
+}
+
+func TestInstallTruncatedDownload(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + fx.ArchiveName:
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(fx.ArchiveBytes)))
+			w.WriteHeader(http.StatusOK)
+			half := len(fx.ArchiveBytes) / 2
+			_, _ = w.Write(fx.ArchiveBytes[:half])
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		case "/checksums.txt":
+			_, _ = w.Write([]byte(fx.ChecksumsBody))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	fx.Release.Assets[0].BrowserDownloadURL = srv.URL + "/" + fx.ArchiveName
+	fx.Release.Assets[1].BrowserDownloadURL = srv.URL + "/checksums.txt"
+
+	host, _ := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath)
+
+	err := r.Install(context.Background(), host, fx.Release, "v0.1.0")
+	if err == nil {
+		t.Fatalf("Install err = nil, want some error (truncated stream)")
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe modified on truncated download: %q", got)
+	}
+}
+
+func TestInstallTarWithMultipleBinaries(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	fx.ArchiveBytes = makeTarGz(t, []tarEntry{
+		{Name: "nistru", Body: []byte("A")},
+		{Name: "pkgdir/nistru", Body: []byte("B")},
+	})
+	fx.ChecksumsBody = fmt.Sprintf("%s  %s\n", sha256Hex(fx.ArchiveBytes), fx.ArchiveName)
+	_ = startAssetServer(t, fx)
+
+	host, _ := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath)
+
+	err := r.Install(context.Background(), host, fx.Release, "v0.1.0")
+	if err == nil || !strings.Contains(err.Error(), "multiple candidate binaries") {
+		t.Fatalf("Install err = %v, want multiple binaries", err)
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe modified on multi-binary archive: %q", got)
+	}
+}
+
+func TestInstallTarWithPathTraversal(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	fx.ArchiveBytes = makeTarGz(t, []tarEntry{
+		{Name: "../../etc/passwd", Body: []byte("root::0:0:root:/root:/bin/sh\n")},
+	})
+	fx.ChecksumsBody = fmt.Sprintf("%s  %s\n", sha256Hex(fx.ArchiveBytes), fx.ArchiveName)
+	_ = startAssetServer(t, fx)
+
+	host, _ := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath)
+
+	err := r.Install(context.Background(), host, fx.Release, "v0.1.0")
+	if err == nil || !strings.Contains(err.Error(), "path-traversal") {
+		t.Fatalf("Install err = %v, want path-traversal", err)
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe modified on traversal archive: %q", got)
+	}
+}
+
+func TestInstallTarWithNoBinary(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	fx.ArchiveBytes = makeTarGz(t, []tarEntry{
+		{Name: "README.md", Body: []byte("# Nistru")},
+	})
+	fx.ChecksumsBody = fmt.Sprintf("%s  %s\n", sha256Hex(fx.ArchiveBytes), fx.ArchiveName)
+	_ = startAssetServer(t, fx)
+
+	host, _ := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath)
+
+	err := r.Install(context.Background(), host, fx.Release, "v0.1.0")
+	if err == nil || !strings.Contains(err.Error(), "no nistru binary") {
+		t.Fatalf("Install err = %v, want no nistru binary", err)
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe modified on no-binary archive: %q", got)
+	}
+}
+
+// TestInstallSwapFailsReverts: pre-create a directory at the .prev path so
+// os.Rename(exe, exe+".prev") fails (overwriting a non-empty dir with a
+// regular file is not permitted). Confirm the exe is left untouched.
+func TestInstallSwapFailsReverts(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+	_ = startAssetServer(t, fx)
+
+	prevDir := exePath + ".prev"
+	if err := os.Mkdir(prevDir, 0o755); err != nil {
+		t.Fatalf("mkdir prev: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(prevDir, "child"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed prev child: %v", err)
+	}
+
+	host, _ := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath)
+
+	err := r.Install(context.Background(), host, fx.Release, "v0.1.0")
+	if err == nil {
+		t.Fatalf("Install err = nil, want swap failure")
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe modified after swap failure: %q", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Rollback tests.
+
+func TestRollbackSuccess(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	newContents := []byte("NEW NISTRU")
+	if err := os.WriteFile(exePath, newContents, 0o755); err != nil {
+		t.Fatalf("seed new: %v", err)
+	}
+	prev := exePath + ".prev"
+	if err := os.WriteFile(prev, dummyExeContents, 0o755); err != nil {
+		t.Fatalf("seed prev: %v", err)
+	}
+	statePath := filepath.Join(dir, "state.json")
+	if err := SaveState(statePath, State{
+		PendingRestartVersion: "v99.0.0",
+		PrevBinaryPath:        prev,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	host, _ := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath)
+
+	if err := r.Rollback(context.Background(), host); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe after rollback = %q, want old contents", got)
+	}
+	if _, err := os.Stat(prev); err == nil {
+		t.Fatalf(".prev still exists after rollback")
+	}
+	st, _ := LoadState(statePath)
+	if st.PendingRestartVersion != "" || st.PrevBinaryPath != "" {
+		t.Fatalf("state not cleared: %+v", st)
+	}
+}
+
+func TestRollbackNoPrev(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	host, rec := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath)
+
+	if err := r.Rollback(context.Background(), host); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe modified on no-prev rollback: %q", got)
+	}
+	if !rec.waitFor(500*time.Millisecond, func(m recordedNotif) bool {
+		return m.Method == "ui/notify" && m.Payload["level"] == "warn" &&
+			strings.Contains(m.Payload["message"], "no previous binary")
+	}) {
+		t.Fatalf("expected 'no previous binary' notify, got %+v", rec.snapshot())
+	}
+}
+
+func TestRollbackIdempotent(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	prev := exePath + ".prev"
+	if err := os.WriteFile(prev, dummyExeContents, 0o755); err != nil {
+		t.Fatalf("seed prev: %v", err)
+	}
+	statePath := filepath.Join(dir, "state.json")
+	if err := SaveState(statePath, State{
+		PendingRestartVersion: "v99.0.0",
+		PrevBinaryPath:        prev,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	host, _ := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath)
+
+	if err := r.Rollback(context.Background(), host); err != nil {
+		t.Fatalf("first Rollback: %v", err)
+	}
+	if err := r.Rollback(context.Background(), host); err != nil {
+		t.Fatalf("second Rollback: %v", err)
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe after double rollback = %q", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Cleanup tests.
+
+func TestCleanupDeletesPrevAfterPendingCleared(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	prev := exePath + ".prev"
+	if err := os.WriteFile(prev, []byte("old"), 0o755); err != nil {
+		t.Fatalf("seed prev: %v", err)
+	}
+	statePath := filepath.Join(dir, "state.json")
+	if err := SaveState(statePath, State{}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	r := newTestInstaller(t, dir, exePath)
+	if err := r.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(prev); err == nil {
+		t.Fatalf(".prev still exists after cleanup")
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe modified by cleanup: %q", got)
+	}
+}
+
+func TestCleanupLeavesPrevIfPendingSet(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	prev := exePath + ".prev"
+	if err := os.WriteFile(prev, []byte("old"), 0o755); err != nil {
+		t.Fatalf("seed prev: %v", err)
+	}
+	statePath := filepath.Join(dir, "state.json")
+	if err := SaveState(statePath, State{
+		PendingRestartVersion: "v99.0.0",
+		PrevBinaryPath:        prev,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	r := newTestInstaller(t, dir, exePath)
+	if err := r.Cleanup(context.Background()); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+	if _, err := os.Stat(prev); err != nil {
+		t.Fatalf(".prev was removed while PendingRestartVersion set: %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// findChecksum unit test.
+
+func TestFindChecksum(t *testing.T) {
+	body := []byte(
+		"# comment line\n" +
+			"abc123  nistru_darwin_arm64.tar.gz\n" +
+			"def456 *nistru_linux_amd64.tar.gz\n" +
+			"\n",
+	)
+	cases := []struct {
+		name string
+		want string
+		ok   bool
+	}{
+		{"nistru_darwin_arm64.tar.gz", "abc123", true},
+		{"nistru_linux_amd64.tar.gz", "def456", true},
+		{"nistru_missing.tar.gz", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := findChecksum(body, tc.name)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("findChecksum(%q) = (%q,%v), want (%q,%v)", tc.name, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Archive-bomb defence (Finding 4 regression).
+
+// TestInstallRejectsTarBombDeclaredSize seeds a tar whose single header
+// declares a size far larger than any sane binary. The pre-read guard must
+// reject it before any bytes are copied.
+func TestInstallRejectsTarBombDeclaredSize(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	// Build a tarball whose header claims 2 MiB but the body is a single
+	// byte. The installer must reject on the header check, not during copy.
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{
+		Name:     "nistru",
+		Mode:     0o755,
+		Size:     2 * 1024 * 1024,
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("WriteHeader: %v", err)
+	}
+	// Write one byte so the tar writer is happy; we'll short-circuit during
+	// header inspection anyway.
+	_, _ = tw.Write(bytes.Repeat([]byte{0}, 2*1024*1024))
+	_ = tw.Close()
+	_ = gz.Close()
+
+	fx.ArchiveBytes = buf.Bytes()
+	fx.ChecksumsBody = fmt.Sprintf("%s  %s\n", sha256Hex(fx.ArchiveBytes), fx.ArchiveName)
+	_ = startAssetServer(t, fx)
+
+	host, _ := newHostRecorder(t)
+	// Cap the whole archive at 1 MiB so the 2 MiB entry trips the guard.
+	r := newTestInstaller(t, dir, exePath,
+		WithMaxArchiveBytes(1024*1024),
+	)
+
+	err := r.Install(context.Background(), host, fx.Release, "v0.1.0")
+	if err == nil {
+		t.Fatalf("Install err = nil, want tar-bomb rejection")
+	}
+	if !strings.Contains(err.Error(), "max decompressed") && !strings.Contains(err.Error(), "exceeds max size") {
+		t.Fatalf("Install err = %v, want 'max decompressed' or 'exceeds max size'", err)
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe modified on tar-bomb rejection: %q", got)
+	}
+	if _, err := os.Stat(exePath + ".prev"); err == nil {
+		t.Fatalf(".prev was created for a rejected archive")
+	}
+}
+
+// TestInstallRejectsTarBombEntryCount seeds a tar with more entries than
+// the entry-count cap allows. Confirms the counter-based guard trips.
+func TestInstallRejectsTarBombEntryCount(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+
+	// 50 zero-byte entries; cap the installer at 10 so the guard trips on
+	// the 11th header.
+	entries := make([]tarEntry, 50)
+	for i := range entries {
+		entries[i] = tarEntry{Name: fmt.Sprintf("padding/e%03d", i), Body: nil}
+	}
+	fx.ArchiveBytes = makeTarGz(t, entries)
+	fx.ChecksumsBody = fmt.Sprintf("%s  %s\n", sha256Hex(fx.ArchiveBytes), fx.ArchiveName)
+	_ = startAssetServer(t, fx)
+
+	host, _ := newHostRecorder(t)
+	r := newTestInstaller(t, dir, exePath, WithMaxArchiveEntries(10))
+
+	err := r.Install(context.Background(), host, fx.Release, "v0.1.0")
+	if err == nil || !strings.Contains(err.Error(), "max entry count") {
+		t.Fatalf("Install err = %v, want 'max entry count'", err)
+	}
+	if got := readFile(t, exePath); !bytes.Equal(got, dummyExeContents) {
+		t.Fatalf("exe modified on entry-count rejection: %q", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// State race regression tests (Findings 1 & 2).
+
+// TestConcurrentCheckerAndInstallStateRace fires an install alongside a
+// simulated checker tick that mutates LastChecked + LastSeenVersion. Both
+// field sets must appear in the final state.json: the pre-fix read-modify-
+// write race would have let the checker's stale snapshot clobber the
+// installer's pending-restart write.
+func TestConcurrentCheckerAndInstallStateRace(t *testing.T) {
+	dir, exePath := newInstallerSetup(t)
+	fx := defaultFixture(t)
+	_ = startAssetServer(t, fx)
+
+	statePath := filepath.Join(dir, "state.json")
+
+	// Use a real Plugin so the serialised updateState helper is exercised
+	// end-to-end. We skip New()'s env reads by constructing directly.
+	p := &Plugin{
+		name:      "autoupdate",
+		repo:      "owner/repo",
+		interval:  time.Hour,
+		client:    &http.Client{Timeout: 5 * time.Second},
+		now:       time.Now,
+		current:   "v0.1.0",
+		statePath: statePath,
+	}
+	// Wire the installer to use the plugin's serialised updater. Also
+	// supply the same statePath so Rollback's read seam (which consults
+	// statePath when updateStateF is absent) can observe state in future
+	// stand-alone tests of the installer.
+	inst := NewInstaller(
+		WithExecutableFunc(func() (string, error) { return exePath, nil }),
+		WithGoos("darwin"),
+		WithGoarch("arm64"),
+		WithInstallerHTTPClient(&http.Client{Timeout: 5 * time.Second}),
+		WithInstallerStatePath(statePath),
+		WithStateUpdater(p.updateState),
+		withFreeBytesFunc(func(string) (int64, error) { return math.MaxInt64, nil }),
+	)
+	p.installer = inst
+
+	host, _ := newHostRecorder(t)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Simulated checker tick: write LastChecked + LastSeenVersion via the
+	// same serialised path the real checker uses.
+	lastChecked := time.Now().UTC().Truncate(time.Second)
+	go func() {
+		defer wg.Done()
+		if err := p.updateState(func(s *State) {
+			s.LastChecked = lastChecked
+			s.LastSeenVersion = "v0.1.0-checker"
+		}); err != nil {
+			t.Errorf("checker updateState: %v", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		if err := inst.Install(context.Background(), host, fx.Release, "v0.1.0"); err != nil {
+			t.Errorf("Install: %v", err)
+		}
+	}()
+
+	wg.Wait()
+
+	got, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got.PendingRestartVersion != "v99.0.0" {
+		t.Fatalf("PendingRestartVersion = %q, want v99.0.0 (installer write lost)", got.PendingRestartVersion)
+	}
+	resolvedExe, _ := filepath.EvalSymlinks(exePath)
+	if got.PrevBinaryPath != resolvedExe+".prev" {
+		t.Fatalf("PrevBinaryPath = %q, want %q (installer write lost)", got.PrevBinaryPath, resolvedExe+".prev")
+	}
+	if got.LastSeenVersion != "v0.1.0-checker" {
+		t.Fatalf("LastSeenVersion = %q, want v0.1.0-checker (checker write lost)", got.LastSeenVersion)
+	}
+	if !got.LastChecked.Equal(lastChecked) {
+		t.Fatalf("LastChecked = %v, want %v (checker write lost)", got.LastChecked, lastChecked)
+	}
+}
+
+// TestSwitchChannelRaceWithChecker drives a real Plugin end-to-end with a
+// slow checker tick. While the tick is parked inside FetchReleases, the
+// test dispatches switch-channel. After the tick unblocks and completes,
+// the channel must still be "dev" and the checker's LastChecked must also
+// be recorded. Pre-fix the checker and switch-channel both did their own
+// read-modify-write cycles against p.state and persisted whole snapshots;
+// interleaving could drop either side's fields.
+func TestSwitchChannelRaceWithChecker(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	t.Setenv(envDisable, "")
+	t.Setenv(envRepo, "")
+	t.Setenv(envChannel, "")
+	t.Setenv(envInterval, "")
+
+	// Slow transport: first release-list request blocks on a gate so the
+	// tick is observably in-flight while we dispatch switch-channel.
+	gate := make(chan struct{})
+	var once sync.Once
+	slow := &slowReleaseTransport{
+		body:  []byte(`[]`),
+		gate:  gate,
+		first: &once,
+	}
+	client := &http.Client{Transport: slow, Timeout: 5 * time.Second}
+
+	p := New(
+		WithRepo("owner/repo"),
+		WithHTTPClient(client),
+		WithInterval(time.Hour), // only the immediate tick matters.
+		WithStatePath(statePath),
+		WithCurrent("v0.1.0"),
+	)
+	_ = newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+
+	// Wait for the checker to enter fetch so it is truly parked.
+	waitUntil(t, 2*time.Second, func() bool { return slow.hit.Load() >= 1 })
+
+	// Flip to dev while the tick is parked inside FetchReleases.
+	_ = p.OnEvent(plugin.ExecuteCommand{ID: "autoupdate:switch-channel"})
+
+	// The switch persists synchronously via updateState.
+	waitUntil(t, 2*time.Second, func() bool {
+		st, err := LoadState(statePath)
+		return err == nil && st.Channel == "dev"
+	})
+
+	// Let the tick finish. With all state writes funnelled through
+	// updateState, the tick's LastChecked save cannot regress the channel.
+	close(gate)
+
+	// The tick posts a statusBar update after its save returns; wait until
+	// LastChecked appears on disk so we know the save landed.
+	waitUntil(t, 2*time.Second, func() bool {
+		st, err := LoadState(statePath)
+		return err == nil && !st.LastChecked.IsZero()
+	})
+
+	st, err := LoadState(statePath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if st.Channel != "dev" {
+		t.Fatalf("Channel = %q after checker finished, want dev (checker clobbered switch-channel)", st.Channel)
+	}
+}
+
+// stubTransport returns a fixed body for every request. Used so tests can
+// build a real Plugin without exercising the real network.
+type stubTransport struct {
+	body []byte
+	hits atomic.Int64
+}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.hits.Add(1)
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Body:          io.NopCloser(bytes.NewReader(s.body)),
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		Request:       req,
+		ContentLength: int64(len(s.body)),
+	}, nil
+}
+
+// slowReleaseTransport blocks the first release-list request on gate so a
+// test can inject ordered operations between fetch-start and fetch-end.
+// Subsequent requests pass through immediately.
+type slowReleaseTransport struct {
+	body  []byte
+	gate  chan struct{}
+	first *sync.Once
+	hit   atomic.Int64
+}
+
+func (s *slowReleaseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.hit.Add(1)
+	s.first.Do(func() { <-s.gate })
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Body:          io.NopCloser(bytes.NewReader(s.body)),
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		Request:       req,
+		ContentLength: int64(len(s.body)),
+	}, nil
+}
+
+// -----------------------------------------------------------------------------
+// Initialize reconciliation regression (Finding 3).
+
+// TestInitializeFinalizesPendingRestart seeds state with a pending version
+// that matches the running binary (i.e. the user already restarted).
+// Initialize must clear the pending fields and remove the .prev file.
+func TestInitializeFinalizesPendingRestart(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	prev := filepath.Join(dir, "nistru.prev")
+	if err := os.WriteFile(prev, []byte("old binary"), 0o755); err != nil {
+		t.Fatalf("seed prev: %v", err)
+	}
+	if err := SaveState(statePath, State{
+		PendingRestartVersion: "v1.2.3",
+		PrevBinaryPath:        prev,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	t.Setenv(envDisable, "")
+	t.Setenv(envRepo, "")
+	t.Setenv(envChannel, "")
+	t.Setenv(envInterval, "")
+
+	p := New(
+		WithRepo("owner/repo"),
+		WithHTTPClient(&http.Client{Transport: &stubTransport{body: []byte(`[]`)}}),
+		WithStatePath(statePath),
+		WithCurrent("v1.2.3"),
+		WithVersionFunc(func() string { return "v1.2.3" }),
+		WithInstaller(&recordingInstaller{}),
+		WithInterval(time.Hour),
+	)
+	_ = newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+
+	waitUntil(t, 2*time.Second, func() bool {
+		st, err := LoadState(statePath)
+		return err == nil && st.PendingRestartVersion == "" && st.PrevBinaryPath == ""
+	})
+	if _, err := os.Stat(prev); err == nil {
+		t.Fatalf(".prev file was not removed after successful restart reconciliation")
+	}
+}
+
+// TestInitializeKeepsPendingWhenVersionMismatch confirms reconciliation is
+// a no-op when the running binary is still the *old* one (user has not
+// restarted yet). The .prev must stay put so rollback works.
+func TestInitializeKeepsPendingWhenVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	prev := filepath.Join(dir, "nistru.prev")
+	if err := os.WriteFile(prev, []byte("old binary"), 0o755); err != nil {
+		t.Fatalf("seed prev: %v", err)
+	}
+	if err := SaveState(statePath, State{
+		PendingRestartVersion: "v1.2.3",
+		PrevBinaryPath:        prev,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	t.Setenv(envDisable, "")
+	t.Setenv(envRepo, "")
+	t.Setenv(envChannel, "")
+	t.Setenv(envInterval, "")
+
+	p := New(
+		WithRepo("owner/repo"),
+		WithHTTPClient(&http.Client{Transport: &stubTransport{body: []byte(`[]`)}}),
+		WithStatePath(statePath),
+		WithCurrent("v1.2.2"),
+		WithVersionFunc(func() string { return "v1.2.2" }),
+		WithInstaller(&recordingInstaller{}),
+		WithInterval(time.Hour),
+	)
+	_ = newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+
+	// Give the checker one immediate tick of headroom so our assertion
+	// isn't racing a just-started goroutine. The tick cannot mutate
+	// PendingRestart/PrevBinaryPath by design (only Install/Rollback do).
+	waitUntil(t, 2*time.Second, func() bool {
+		st, err := LoadState(statePath)
+		return err == nil && !st.LastChecked.IsZero()
+	})
+	st, _ := LoadState(statePath)
+	if st.PendingRestartVersion != "v1.2.3" {
+		t.Fatalf("PendingRestartVersion cleared despite version mismatch: %+v", st)
+	}
+	if _, err := os.Stat(prev); err != nil {
+		t.Fatalf(".prev was removed despite version mismatch: %v", err)
+	}
+}
+
+// kill unused warning for io import if trim happens.
+var _ = io.Discard

--- a/internal/plugins/autoupdate/install_windows.go
+++ b/internal/plugins/autoupdate/install_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package autoupdate
+
+import "math"
+
+// freeBytes returns math.MaxInt64 on Windows. The real in-place swap path
+// is not implemented for Windows in this MVP — Install() short-circuits
+// with a notify-only fallback before the disk-space probe is consulted.
+// Keeping this stub ensures the package compiles on Windows.
+func freeBytes(_ string) (int64, error) {
+	return math.MaxInt64, nil
+}

--- a/internal/plugins/autoupdate/noop_installer.go
+++ b/internal/plugins/autoupdate/noop_installer.go
@@ -1,0 +1,45 @@
+package autoupdate
+
+import (
+	"context"
+
+	"github.com/savimcio/nistru/plugin"
+)
+
+// noopInstaller is the placeholder Installer used until T7 wires the real
+// binary-swap path. It surfaces a one-line warning through PostNotif so the
+// user sees the command dispatch succeeded even though nothing happens yet.
+type noopInstaller struct{}
+
+// Install implements Installer. The noop variant posts a "not yet wired"
+// warning and returns nil so the palette command never appears to fail.
+func (noopInstaller) Install(ctx context.Context, host *plugin.Host, rel Release, cur string) error {
+	_ = ctx
+	_ = rel
+	_ = cur
+	if host != nil {
+		_ = host.PostNotif("autoupdate", "ui/notify", map[string]string{
+			"level":   "warn",
+			"message": "auto-update install is not yet wired (T7 pending)",
+		})
+	}
+	return nil
+}
+
+// Rollback implements Installer. Same noop semantics as Install.
+func (noopInstaller) Rollback(ctx context.Context, host *plugin.Host) error {
+	_ = ctx
+	if host != nil {
+		_ = host.PostNotif("autoupdate", "ui/notify", map[string]string{
+			"level":   "warn",
+			"message": "auto-update rollback is not yet wired (T7 pending)",
+		})
+	}
+	return nil
+}
+
+// Compile-time assertion that noopInstaller satisfies Installer. Kept so the
+// seam remains a drop-in replacement for tests that want to bypass the real
+// installer, and so staticcheck does not flag the type as unused now that
+// New() defaults to NewInstaller().
+var _ Installer = noopInstaller{}

--- a/internal/plugins/autoupdate/semver.go
+++ b/internal/plugins/autoupdate/semver.go
@@ -1,0 +1,73 @@
+package autoupdate
+
+import (
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// isUnknownVersion reports whether v should be treated as "behind everything
+// else" — the empty string, the literal "unknown", or the go toolchain's
+// "(devel)" placeholder for unstamped local builds.
+func isUnknownVersion(v string) bool {
+	switch v {
+	case "", "unknown", "(devel)":
+		return true
+	default:
+		return false
+	}
+}
+
+// ensureVPrefix prepends "v" when missing so inputs survive semver.Compare,
+// which requires the leading "v".
+func ensureVPrefix(v string) string {
+	if strings.HasPrefix(v, "v") {
+		return v
+	}
+	return "v" + v
+}
+
+// CompareVersions returns -1, 0, or +1 depending on whether a is less than,
+// equal to, or greater than b under semver ordering.
+//
+// Inputs are first checked for the "unknown" sentinels ("", "unknown",
+// "(devel)"); an unknown version sorts strictly before any known version,
+// and two unknowns compare equal.
+//
+// Inputs missing a leading "v" are tolerated. Any post-normalization input
+// that is not valid semver per semver.IsValid is also treated as unknown.
+func CompareVersions(a, b string) int {
+	aUnknown := isUnknownVersion(a)
+	bUnknown := isUnknownVersion(b)
+
+	na := ensureVPrefix(a)
+	nb := ensureVPrefix(b)
+
+	if !aUnknown && !semver.IsValid(na) {
+		aUnknown = true
+	}
+	if !bUnknown && !semver.IsValid(nb) {
+		bUnknown = true
+	}
+
+	switch {
+	case aUnknown && bUnknown:
+		return 0
+	case aUnknown:
+		return -1
+	case bUnknown:
+		return 1
+	}
+	return semver.Compare(na, nb)
+}
+
+// NormalizeVersion returns the v-prefixed canonical form of v for display
+// (e.g. "0.1" -> "v0.1.0"). Inputs that are not valid semver after adding
+// the "v" prefix are returned unchanged so callers can still render them.
+func NormalizeVersion(v string) string {
+	n := ensureVPrefix(v)
+	if !semver.IsValid(n) {
+		return v
+	}
+	return semver.Canonical(n)
+}

--- a/internal/plugins/autoupdate/semver_test.go
+++ b/internal/plugins/autoupdate/semver_test.go
@@ -1,0 +1,57 @@
+package autoupdate
+
+import "testing"
+
+func TestCompareVersions(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{"minor-less", "v0.1.0", "v0.2.0", -1},
+		{"minor-greater", "v0.2.0", "v0.1.0", 1},
+		{"equal", "v0.2.0", "v0.2.0", 0},
+		{"stable-gt-prerelease", "v0.2.0", "v0.2.0-dev.20260421-abc1234", 1},
+		{"prerelease-ordering", "v0.2.0-dev.20260420", "v0.2.0-dev.20260421", -1},
+		{"missing-v-prefix-equal", "0.1.0", "v0.1.0", 0},
+		{"unknown-lt-known", "unknown", "v0.1.0", -1},
+		{"known-gt-unknown", "v0.1.0", "unknown", 1},
+		{"both-unknown", "unknown", "unknown", 0},
+		{"empty-lt-known", "", "v0.1.0", -1},
+		{"devel-lt-known", "(devel)", "v0.1.0", -1},
+		{"garbage-lt-known", "garbage", "v0.1.0", -1},
+		{"known-gt-garbage", "v0.1.0", "garbage", 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CompareVersions(tc.a, tc.b)
+			if got != tc.want {
+				t.Fatalf("CompareVersions(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"missing-v-prefix", "0.1.0", "v0.1.0"},
+		{"already-canonical", "v0.1.0", "v0.1.0"},
+		{"short-form-canonicalized", "v0.1", "v0.1.0"},
+		{"invalid-passthrough", "garbage", "garbage"},
+		{"empty-passthrough", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizeVersion(tc.in)
+			if got != tc.want {
+				t.Fatalf("NormalizeVersion(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/plugins/autoupdate/state.go
+++ b/internal/plugins/autoupdate/state.go
@@ -1,0 +1,100 @@
+package autoupdate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// State is the persisted on-disk state for the auto-update plugin. Fields are
+// omitempty so a zero-value state serializes to "{}" and forward-compatible
+// additions don't pollute existing files.
+type State struct {
+	LastChecked           time.Time `json:"lastChecked,omitzero"`
+	LastSeenVersion       string    `json:"lastSeenVersion,omitempty"`
+	Channel               string    `json:"channel,omitempty"`
+	PendingRestartVersion string    `json:"pendingRestartVersion,omitempty"`
+	PrevBinaryPath        string    `json:"prevBinaryPath,omitempty"`
+}
+
+// DefaultChannel is the MVP default release channel.
+func DefaultChannel() string { return "release" }
+
+// StatePath returns the canonical path for the auto-update state file:
+// <UserConfigDir>/nistru/autoupdate/state.json. It does not create any
+// directories; callers (SaveState) handle mkdir lazily.
+func StatePath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("autoupdate: user config dir: %w", err)
+	}
+	return filepath.Join(dir, "nistru", "autoupdate", "state.json"), nil
+}
+
+// LoadState reads and decodes the state file at path. It is intentionally
+// forgiving: a missing file yields a zero-value state with no error, and a
+// corrupt or malformed file logs a warning to stderr and also yields a
+// zero-value state with no error — the plugin must never refuse to start
+// because its state is bad. Only genuinely unexpected I/O failures (e.g. a
+// permission-denied on an existing file) are surfaced.
+func LoadState(path string) (State, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return State{}, nil
+		}
+		return State{}, fmt.Errorf("autoupdate: read state: %w", err)
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		fmt.Fprintf(os.Stderr, "autoupdate: state file %q is corrupt, ignoring: %v\n", path, err)
+		return State{}, nil
+	}
+	return s, nil
+}
+
+// SaveState atomically writes s to path. It creates the parent directory
+// (0o755) if needed, marshals to indented JSON, writes to a sibling tmpfile
+// in the same directory, fsyncs, and renames into place. On any error the
+// tmpfile is removed so no ".tmp" siblings accumulate.
+func SaveState(path string, s State) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("autoupdate: mkdir state dir: %w", err)
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("autoupdate: marshal state: %w", err)
+	}
+	f, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("autoupdate: create tmp: %w", err)
+	}
+	tmp := f.Name()
+	// cleanup on any error path below
+	cleanup := func() { _ = os.Remove(tmp) }
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("autoupdate: write tmp: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		cleanup()
+		return fmt.Errorf("autoupdate: sync tmp: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("autoupdate: close tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		cleanup()
+		return fmt.Errorf("autoupdate: rename tmp: %w", err)
+	}
+	return nil
+}

--- a/internal/plugins/autoupdate/state_test.go
+++ b/internal/plugins/autoupdate/state_test.go
@@ -1,0 +1,206 @@
+package autoupdate
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStatePathIsUnderUserConfigDir(t *testing.T) {
+	got, err := StatePath()
+	if err != nil {
+		t.Fatalf("StatePath: %v", err)
+	}
+	base, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir: %v", err)
+	}
+	if !strings.HasPrefix(got, base) {
+		t.Errorf("StatePath %q is not under UserConfigDir %q", got, base)
+	}
+	want := filepath.Join("nistru", "autoupdate", "state.json")
+	if !strings.HasSuffix(got, want) {
+		t.Errorf("StatePath %q does not end with %q", got, want)
+	}
+}
+
+func TestLoadStateMissingReturnsZero(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist", "state.json")
+	s, err := LoadState(path)
+	if err != nil {
+		t.Fatalf("LoadState(missing): err=%v", err)
+	}
+	if s != (State{}) {
+		t.Errorf("LoadState(missing): want zero State, got %+v", s)
+	}
+}
+
+func TestLoadStateCorruptReturnsZero(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+	s, err := LoadState(path)
+	if err != nil {
+		t.Fatalf("LoadState(corrupt): err=%v", err)
+	}
+	if s != (State{}) {
+		t.Errorf("LoadState(corrupt): want zero State, got %+v", s)
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	// Pin timestamp precision by round-tripping through JSON once. Go's
+	// time.Time JSON marshaling uses RFC3339Nano, so a raw time.Now() may
+	// carry monotonic clock bits / ns precision that don't survive the
+	// round trip.
+	now := time.Now().UTC()
+	raw, err := json.Marshal(now)
+	if err != nil {
+		t.Fatalf("marshal now: %v", err)
+	}
+	var pinned time.Time
+	if err := json.Unmarshal(raw, &pinned); err != nil {
+		t.Fatalf("unmarshal pinned: %v", err)
+	}
+
+	want := State{
+		LastChecked:           pinned,
+		LastSeenVersion:       "v1.2.3",
+		Channel:               "release",
+		PendingRestartVersion: "v1.2.4",
+		PrevBinaryPath:        "/tmp/nistru.prev",
+	}
+	if err := SaveState(path, want); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	got, err := LoadState(path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if !got.LastChecked.Equal(want.LastChecked) {
+		t.Errorf("LastChecked: want %v, got %v", want.LastChecked, got.LastChecked)
+	}
+	if got.LastSeenVersion != want.LastSeenVersion {
+		t.Errorf("LastSeenVersion: want %q, got %q", want.LastSeenVersion, got.LastSeenVersion)
+	}
+	if got.Channel != want.Channel {
+		t.Errorf("Channel: want %q, got %q", want.Channel, got.Channel)
+	}
+	if got.PendingRestartVersion != want.PendingRestartVersion {
+		t.Errorf("PendingRestartVersion: want %q, got %q", want.PendingRestartVersion, got.PendingRestartVersion)
+	}
+	if got.PrevBinaryPath != want.PrevBinaryPath {
+		t.Errorf("PrevBinaryPath: want %q, got %q", want.PrevBinaryPath, got.PrevBinaryPath)
+	}
+}
+
+func TestSaveIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	// First write: a good state.
+	first := State{LastSeenVersion: "v1.0.0", Channel: "release"}
+	if err := SaveState(path, first); err != nil {
+		t.Fatalf("SaveState #1: %v", err)
+	}
+	assertNoTmpSiblings(t, dir, "state.json")
+
+	// Simulate a prior crashed write: a stale .tmp sibling file.
+	stale := filepath.Join(dir, "state.json.stale.tmp")
+	if err := os.WriteFile(stale, []byte("garbage"), 0o644); err != nil {
+		t.Fatalf("seed stale tmp: %v", err)
+	}
+
+	// Second write: a new good state. This should leave the real file valid
+	// and should not touch the stale tmp we planted (we clean it up manually
+	// afterwards to keep the invariant check meaningful).
+	second := State{LastSeenVersion: "v2.0.0", Channel: "beta"}
+	if err := SaveState(path, second); err != nil {
+		t.Fatalf("SaveState #2: %v", err)
+	}
+
+	// The final state.json must parse and reflect the second write.
+	got, err := LoadState(path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if got.LastSeenVersion != "v2.0.0" || got.Channel != "beta" {
+		t.Errorf("final state: want {v2.0.0, beta}, got %+v", got)
+	}
+
+	// SaveState must not have left its own tmp file behind. The only tmp in
+	// the dir should be the one we manually planted.
+	if _, err := os.Stat(stale); err != nil {
+		t.Errorf("stale tmp was unexpectedly removed: %v", err)
+	}
+	if err := os.Remove(stale); err != nil {
+		t.Fatalf("remove stale tmp: %v", err)
+	}
+	assertNoTmpSiblings(t, dir, "state.json")
+}
+
+func TestSaveCreatesParentDir(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "a", "b", "c")
+	path := filepath.Join(nested, "state.json")
+
+	// Sanity: parent must not exist yet.
+	if _, err := os.Stat(nested); !errorsIsNotExist(err) {
+		t.Fatalf("precondition: nested dir should not exist yet, stat err=%v", err)
+	}
+
+	if err := SaveState(path, State{Channel: "release"}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	info, err := os.Stat(nested)
+	if err != nil {
+		t.Fatalf("stat nested: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("nested %q is not a directory", nested)
+	}
+	// On Unix the created dir should be mode 0o755 (subject to umask). Rather
+	// than asserting an exact mode (umask-dependent), assert the dir is at
+	// least user-rwx and that the file inside exists.
+	if info.Mode().Perm()&0o700 != 0o700 {
+		t.Errorf("nested dir perm %v missing user rwx", info.Mode().Perm())
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("state file missing after save: %v", err)
+	}
+}
+
+// assertNoTmpSiblings asserts there are no "<base>.*.tmp" files in dir. A
+// stray tmp means SaveState leaked a partial write.
+func assertNoTmpSiblings(t *testing.T, dir, base string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, base+".") && strings.HasSuffix(name, ".tmp") {
+			t.Errorf("stray tmp sibling left behind: %s", name)
+		}
+	}
+}
+
+func errorsIsNotExist(err error) bool {
+	if err == nil {
+		return false
+	}
+	return os.IsNotExist(err) || err == fs.ErrNotExist
+}

--- a/internal/plugins/autoupdate/version.go
+++ b/internal/plugins/autoupdate/version.go
@@ -1,0 +1,59 @@
+// Package autoupdate provides the in-process auto-update plugin for nistru.
+//
+// Version resolution order for Current():
+//  1. The ldflags-injected value registered via SetVersion — the nistru
+//     main package calls SetVersion(Version) at startup so `go build`
+//     binaries stamped via `-X main.Version=...` resolve correctly. The
+//     literal "dev" sentinel is treated as "not injected" so an un-stamped
+//     binary does not poison the comparison.
+//  2. runtime/debug.ReadBuildInfo() — uses info.Main.Version when it is
+//     non-empty and not the placeholder "(devel)". This is the value set
+//     by `go install github.com/savimcio/nistru/cmd/nistru@<tag>`.
+//  3. Fallback: "unknown" — returned for local `go build` (which yields
+//     "(devel)") or when build info is unavailable for any reason.
+//
+// The two-source arrangement fixes the "infinite install loop" regression
+// where a locally-built binary reported "unknown" to the checker but
+// printed the correct tag to `-version`: every release then compared as
+// newer and re-installed on every check.
+package autoupdate
+
+import (
+	"runtime/debug"
+	"sync/atomic"
+)
+
+// injected holds the SetVersion-recorded string. Stored in an atomic so
+// concurrent readers (the checker goroutine, the palette install command)
+// see a consistent value without taking the plugin mutex. The zero value
+// (empty string) means "no injection has happened yet".
+var injected atomic.Value // stores string
+
+// SetVersion records the version string the running binary reports. It is
+// typically called from cmd/nistru/main.go with the ldflags-stamped
+// Version symbol before the plugin starts. Passing the literal "dev"
+// sentinel clears the injection so Current() falls back to ReadBuildInfo.
+// Safe to call concurrently; last writer wins.
+func SetVersion(v string) {
+	if v == "dev" {
+		v = ""
+	}
+	injected.Store(v)
+}
+
+// Current returns a best-effort current version string for the running
+// nistru binary. See package doc for resolution order.
+func Current() string {
+	if v, _ := injected.Load().(string); v != "" {
+		return v
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	v := info.Main.Version
+	if v == "" || v == "(devel)" {
+		return "unknown"
+	}
+	return v
+}

--- a/internal/plugins/autoupdate/version_test.go
+++ b/internal/plugins/autoupdate/version_test.go
@@ -1,0 +1,55 @@
+package autoupdate
+
+import "testing"
+
+// TestCurrentNonEmpty asserts Current() returns a non-empty string. Under
+// the go test binary, ReadBuildInfo() is populated, so the function must
+// always return either a real version or the "unknown" fallback.
+func TestCurrentNonEmpty(t *testing.T) {
+	t.Cleanup(func() { SetVersion("") })
+	SetVersion("")
+	if got := Current(); got == "" {
+		t.Fatalf("Current() = %q, want non-empty", got)
+	}
+}
+
+// TestCurrentDoesNotPanic guards against future regressions in the
+// resolution logic (e.g. a nil deref on info.Main).
+func TestCurrentDoesNotPanic(t *testing.T) {
+	t.Cleanup(func() { SetVersion("") })
+	SetVersion("")
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Current() panicked: %v", r)
+		}
+	}()
+	_ = Current()
+}
+
+// TestCurrentPrefersInjectedVersion exercises the SetVersion/Current
+// contract: a non-empty, non-"dev" injection overrides ReadBuildInfo, while
+// "" and the "dev" sentinel both fall back to the build-info resolution.
+// This is the Finding-5 regression — without it, a locally-built nistru
+// binary prints a real tag via `-version` but the checker sees "unknown"
+// and loops re-installing every release on every poll.
+func TestCurrentPrefersInjectedVersion(t *testing.T) {
+	t.Cleanup(func() { SetVersion("") })
+
+	SetVersion("v0.2.0")
+	if got := Current(); got != "v0.2.0" {
+		t.Fatalf("Current() with injection = %q, want v0.2.0", got)
+	}
+
+	// "dev" is the un-stamped ldflags default — treat as absent so a
+	// release-channel comparison does not trust it.
+	SetVersion("dev")
+	if got := Current(); got == "v0.2.0" {
+		t.Fatalf("Current() after SetVersion(dev) = %q, want fallback (not stale injection)", got)
+	}
+
+	// Empty is explicit clear.
+	SetVersion("")
+	if got := Current(); got == "v0.2.0" {
+		t.Fatalf("Current() after SetVersion(empty) = %q, want fallback", got)
+	}
+}

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -152,3 +152,11 @@ type Plugin interface {
 	// resources. Distinct from the Shutdown event struct.
 	Shutdown() error
 }
+
+// HostAware is an optional extension implemented by in-process plugins that
+// need to call back into the Host from their own goroutines (e.g. to post
+// asynchronous status-bar updates). The Host calls SetHost exactly once,
+// before the Initialize event is dispatched.
+type HostAware interface {
+	SetHost(h *Host)
+}

--- a/plugin/host.go
+++ b/plugin/host.go
@@ -140,6 +140,10 @@ func NewHost(registry *Registry) *Host {
 // Start records the workspace root and readies the host. Out-of-process
 // plugins are not spawned here; they come online lazily on their first
 // matching activation event.
+//
+// In-process plugins that satisfy HostAware receive a SetHost call before
+// this method returns, giving them a handle they can use from background
+// goroutines (via PostNotif) once Initialize is delivered.
 func (h *Host) Start(rootPath string) error {
 	h.mu.Lock()
 	if h.started {
@@ -149,7 +153,47 @@ func (h *Host) Start(rootPath string) error {
 	h.rootPath = rootPath
 	h.started = true
 	h.mu.Unlock()
+
+	// Wire HostAware plugins outside h.mu: SetHost is user code and may do
+	// arbitrary work; holding the host lock would invite deadlocks if an
+	// implementation reaches back into the host during its own setup.
+	for _, p := range h.registry.InProc() {
+		if hp, ok := p.(HostAware); ok {
+			hp.SetHost(h)
+		}
+	}
 	return nil
+}
+
+// PostNotif enqueues a synthetic JSON-RPC notification on the host's
+// inbound channel, as if it had arrived from an out-of-process plugin.
+// Safe to call from any goroutine. Non-blocking: if the inbound channel
+// is full, the notification is dropped and a warning is written to
+// stderr. This is primarily for in-process plugins that need to report
+// status from background work; out-of-process plugins already have a
+// dedicated writer goroutine and should not call this method.
+//
+// Host-side bookkeeping (e.g. commands/register) is applied synchronously
+// before the channel send, so callers see command registration as
+// effective on return even if the inbound buffer is saturated.
+func (h *Host) PostNotif(plugin, method string, params any) error {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("plugin: PostNotif marshal %s: %w", method, err)
+	}
+	msg := PluginNotifMsg{Plugin: plugin, Method: method, Params: raw}
+	// Drive host-side bookkeeping (e.g. commands/register) synchronously
+	// so callers see command registration as effective on return.
+	// handleInternal is idempotent: registerCommand/unregisterCommand are
+	// CAS loops against the commands atomic.Value.
+	h.handleInternal(msg)
+	select {
+	case h.inbound <- msg:
+		return nil
+	default:
+		fmt.Fprintf(os.Stderr, "plugin: PostNotif(%s:%s) dropped: inbound full\n", plugin, method)
+		return errors.New("plugin: inbound channel full")
+	}
 }
 
 // Emit delivers event to every plugin whose activation matches. For in-proc

--- a/plugin/host_test.go
+++ b/plugin/host_test.go
@@ -145,6 +145,145 @@ func TestHost_PaneByName(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
+// HostAware / PostNotif exercises.
+
+// hostAwarePlugin is a minimal in-proc plugin that records the host passed to
+// SetHost. Declared locally to avoid leaking HostAware semantics into the
+// default test fixtures, which must stay ignorant of the optional interface.
+type hostAwarePlugin struct {
+	fakeInProcPlugin
+	mu  sync.Mutex
+	got *Host
+}
+
+func (p *hostAwarePlugin) SetHost(h *Host) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.got = h
+}
+
+func (p *hostAwarePlugin) host() *Host {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.got
+}
+
+func TestHostSetsHostAwareOnStart(t *testing.T) {
+	p := &hostAwarePlugin{
+		fakeInProcPlugin: fakeInProcPlugin{name: "aware", acts: []string{"onStart"}},
+	}
+	h := newHostWithPlugins(p)
+	if got := p.host(); got != h {
+		t.Fatalf("SetHost got %p, want host %p", got, h)
+	}
+}
+
+func TestPostNotifDeliversToInbound(t *testing.T) {
+	p := &fakeInProcPlugin{name: "myplugin", acts: []string{"onStart"}}
+	h := newHostWithPlugins(p)
+
+	type payload struct {
+		Level   string `json:"level"`
+		Message string `json:"message"`
+	}
+	want := payload{Level: "info", Message: "hello"}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.PostNotif("myplugin", "ui/notify", want)
+	}()
+
+	cmd := h.Recv()
+	msg := cmd().(PluginMsg)
+
+	if err := <-done; err != nil {
+		t.Fatalf("PostNotif: %v", err)
+	}
+	n, ok := msg.(PluginNotifMsg)
+	if !ok {
+		t.Fatalf("msg = %T, want PluginNotifMsg", msg)
+	}
+	if n.Plugin != "myplugin" || n.Method != "ui/notify" {
+		t.Fatalf("notif = %+v, want {myplugin ui/notify ...}", n)
+	}
+	var got payload
+	if err := json.Unmarshal(n.Params, &got); err != nil {
+		t.Fatalf("unmarshal params: %v", err)
+	}
+	if got != want {
+		t.Fatalf("params = %+v, want %+v", got, want)
+	}
+}
+
+func TestPostNotifCommandRegistration(t *testing.T) {
+	p := &fakeInProcPlugin{name: "cmds", acts: []string{"onStart"}}
+	h := newHostWithPlugins(p)
+
+	params := struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}{ID: "cmds.do", Title: "Do a thing"}
+
+	if err := h.PostNotif("cmds", "commands/register", params); err != nil {
+		t.Fatalf("PostNotif: %v", err)
+	}
+
+	// Synchronous bookkeeping: the command must be visible immediately,
+	// without anyone having drained the inbound channel.
+	cmds := h.Commands()
+	ref, ok := cmds["cmds.do"]
+	if !ok {
+		t.Fatalf("Commands()[cmds.do] missing; have %+v", cmds)
+	}
+	if ref.Plugin != "cmds" || ref.Title != "Do a thing" {
+		t.Fatalf("CommandRef = %+v, want {cmds \"Do a thing\"}", ref)
+	}
+
+	// Drain the synthetic notif so the channel doesn't block future tests.
+	<-h.inbound
+}
+
+func TestPostNotifDropsOnFullInbound(t *testing.T) {
+	p := &fakeInProcPlugin{name: "flood", acts: []string{"onStart"}}
+	h := newHostWithPlugins(p)
+
+	// Fill the inbound channel to capacity via PostNotif itself. Each call
+	// runs handleInternal (a no-op for ui/notify) and then a non-blocking
+	// send; we expect every call up to inboundCap to succeed.
+	for i := range inboundCap {
+		if err := h.PostNotif("flood", "ui/notify", map[string]string{
+			"message": "fill",
+		}); err != nil {
+			t.Fatalf("PostNotif(#%d) unexpectedly failed: %v", i, err)
+		}
+	}
+
+	// Guard against a silently hung call by timing out the next PostNotif.
+	// The non-blocking send must return promptly with the "inbound full"
+	// sentinel error.
+	done := make(chan error, 1)
+	go func() {
+		done <- h.PostNotif("flood", "ui/notify", map[string]string{
+			"message": "overflow",
+		})
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("PostNotif on full inbound returned nil, want error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("PostNotif blocked on full inbound; want non-blocking drop")
+	}
+
+	// Drain so the host can be shut down cleanly (the test doesn't care
+	// about the messages themselves).
+	for range inboundCap {
+		<-h.inbound
+	}
+}
+
+// -----------------------------------------------------------------------------
 // Out-of-proc host exercises.
 
 func TestHost_SpawnAndInitialize(t *testing.T) {


### PR DESCRIPTION
## Summary

First-party auto-update plugin for Nistru. Background-checks GitHub Releases, surfaces available updates in the status bar, and exposes palette commands to install, roll back, and switch channels (release / dev).

- **In-place binary swap on POSIX** with SHA256 verification, atomic rename + `.prev` sidecar for rollback. Windows falls back to printing the `go install` command.
- **Explicit consent** — the checker never auto-installs; only palette invocation of `autoupdate:install` triggers a swap. Pinned by a test.
- **Two small host additions** (`plugin.HostAware`, `Host.PostNotif`) enable any future in-proc plugin to post async status updates from a background goroutine.
- **Boot-path fix** — `NewModel` now emits `plugin.Initialize`, which was silently never fired before; any `onStart`-activated plugin was effectively dormant.

## Config (env vars)

    NISTRU_AUTOUPDATE_DISABLE=1       disable background checks
    NISTRU_AUTOUPDATE_INTERVAL=30m    override check cadence
    NISTRU_AUTOUPDATE_CHANNEL=dev     track prereleases
    NISTRU_AUTOUPDATE_REPO=org/name   point at a fork

## Palette commands

`autoupdate:check`, `autoupdate:install`, `autoupdate:rollback`, `autoupdate:switch-channel`, `autoupdate:release-notes`.

## Test plan

- [x] `make ci` green (coverage 72.8% overall, 77.2% on the autoupdate package)
- [x] `make race` green (checker goroutine + install path are the chief race surfaces)
- [x] `make e2e` green with no golden-file drift
- [x] Install tests run `-count=3 -race`
- [x] Full-stack integration test: checker → PostNotif → Host.inbound → Model.Update → statusSegments
- [x] Boot-path regression test: `NewModel` populates `m.commands` with all five `autoupdate:*` IDs
- [x] Cross-model adversarial review via `/codex:rescue` — five findings addressed with fail-before-pass regression tests
- [ ] Manual smoke test: `./bin/nistru` with `NISTRU_AUTOUPDATE_REPO=cli/cli` shows a green `↑ <tag>` status segment
- [ ] Manual install+rollback round-trip in a throwaway dir

## Prerequisites (follow-up issues)

- Release pipeline: goreleaser config producing per-platform tarballs + `checksums.txt` per GitHub Release (plugin falls back to printing the `go install` command gracefully until this lands).
- Dev-channel tagging convention: `vX.Y.Z-dev.<UTC>.<shortsha>` marked as prereleases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)