### PR TITLE
feat(config): layered TOML settings with reload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Nistru — project guide for Claude Code
 
-Nistru is a Bubble Tea TUI editor with an in-proc + out-of-proc plugin system. The editor core lives in [internal/editor/](internal/editor/) ([model.go](internal/editor/model.go), [editor.go](internal/editor/editor.go), [palette.go](internal/editor/palette.go), [autosave.go](internal/editor/autosave.go)); the binary entry point is [cmd/nistru/main.go](cmd/nistru/main.go); first-party in-proc plugins live under [internal/plugins/](internal/plugins/); the host lives in [plugin/](plugin/); the plugin SDK and harness in [sdk/plugsdk/](sdk/plugsdk/); examples in [examples/](examples/). See [docs/testing.md](docs/testing.md) for the full testing strategy. This file is the fast rules.
+Nistru is a Bubble Tea TUI editor with an in-proc + out-of-proc plugin system. The editor core lives in [internal/editor/](internal/editor/) ([model.go](internal/editor/model.go), [editor.go](internal/editor/editor.go), [palette.go](internal/editor/palette.go), [autosave.go](internal/editor/autosave.go)); the layered TOML config (user + project + env, threaded into editor and plugins) lives in [internal/config/](internal/config/); the binary entry point is [cmd/nistru/main.go](cmd/nistru/main.go); first-party in-proc plugins live under [internal/plugins/](internal/plugins/); the host lives in [plugin/](plugin/); the plugin SDK and harness in [sdk/plugsdk/](sdk/plugsdk/); examples in [examples/](examples/). See [docs/testing.md](docs/testing.md) for the full testing strategy. This file is the fast rules.
 
 ## Commands
 
@@ -38,6 +38,7 @@ See [docs/testing.md](docs/testing.md) for when each tier applies.
 - Touching [sdk/plugsdk/plugsdk.go](sdk/plugsdk/plugsdk.go) → update [sdk/plugsdk/plugsdk_test.go](sdk/plugsdk/plugsdk_test.go); if a new public harness API is needed, add it to [sdk/plugsdk/plugintest/](sdk/plugsdk/plugintest/).
 - Adding a new **plugin event or effect** → extend tests on both sides: host side in [plugin/host_test.go](plugin/host_test.go), SDK side in [sdk/plugsdk/plugsdk_test.go](sdk/plugsdk/plugsdk_test.go), and the harness in [sdk/plugsdk/plugintest/plugintest.go](sdk/plugsdk/plugintest/plugintest.go).
 - Adding a new **palette command or keybinding** → [internal/editor/palette_test.go](internal/editor/palette_test.go) unit + either [internal/editor/model_component_test.go](internal/editor/model_component_test.go) or [internal/editor/model_e2e_test.go](internal/editor/model_e2e_test.go) flow.
+- Touching [internal/config/](internal/config/) → extend the unit tests in the same package; if the public API changes (new field/type), update [docs/plugins.md](docs/plugins.md) and the TOML schema section there.
 
 ## Goldens
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,44 @@ The editor is modal. It opens in **Normal** mode (cursor navigation). Press `i`,
 
 Autosave is enabled by default. After any buffer change, a 250 ms idle debounce schedules a write; rapid typing produces exactly one write when typing stops. Writes are atomic (write to `<path>.tmp`, then rename over the original), so a killed process never leaves a half-written file. The right side of the status bar shows `● unsaved` while dirty and `✓ saved` for about a second after each flush. A size guard refuses to open files larger than 1 MiB, and binary files are refused if a NUL byte appears in the first 512 bytes.
 
+## Configuration
+
+Nistru reads layered TOML from two files. Lowest-priority wins first:
+
+1. Built-in defaults.
+2. `~/.config/nistru/config.toml` — user-wide.
+3. `<root>/.nistru/config.toml` — project-local (overrides user).
+4. `NISTRU_*` environment variables — emergency override.
+
+Missing files are not errors; malformed TOML is reported as a startup warning on stderr. See [internal/config/](internal/config/) for the schema.
+
+Minimal example:
+
+```toml
+[ui]
+tree_width = 40
+
+[autosave]
+save_debounce = "500ms"
+
+[plugins.autoupdate]
+channel  = "dev"
+interval = "30m"
+```
+
+Four palette commands (`Ctrl+P`) manage settings:
+
+| Command | Action |
+|---|---|
+| `Nistru: Open User Settings` | open `~/.config/nistru/config.toml` (seeded with commented defaults if absent) |
+| `Nistru: Open Project Settings` | open `<root>/.nistru/config.toml` (seeded if absent) |
+| `Nistru: Reload Settings` | reparse both files, re-emit `Initialize` to activated plugins |
+| `Nistru: Show Resolved Config` | dump the fully-merged config to `<root>/.nistru/.resolved-config.toml` and open it |
+
+**Reload behaviour.** `Nistru: Reload Settings` takes effect immediately for app-level keybindings (save/quit/palette/focus), UI sizes (tree width, status fade), debounces, and plugin config (`OnConfig` is re-fired on every activated plugin). The in-editor Ctrl bindings (`ctrl+z`/`y`/`x`/`c`/`v`) and the `ui.relative_numbers` flag are baked into the underlying vim component at editor-instance construction time; when any of them changes on reload, the editor instance is rebuilt in place so the new setting is in effect without opening another file. Buffer content and the open file are preserved across the rebuild, but cursor position and vim mode reset to the top of the file in Normal mode.
+
+**Keymap unbinding.** Setting a keybinding to the empty string (e.g. `save = ""`) falls back to the default binding; there is no way to fully unbind an action today.
+
 ## Auto-update
 
 Nistru ships with a first-party `autoupdate` plugin that watches GitHub Releases for newer versions. It is enabled by default, runs quietly in the background, and never swaps the binary without explicit palette invocation.

--- a/cmd/nistru/main.go
+++ b/cmd/nistru/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/savimcio/nistru/internal/config"
 	"github.com/savimcio/nistru/internal/editor"
 	"github.com/savimcio/nistru/internal/plugins/autoupdate"
 )
@@ -25,11 +26,22 @@ func main() {
 		fmt.Println(Version)
 		os.Exit(0)
 	}
+	// Resolve the layered TOML config before the editor starts. Missing
+	// files aren't errors; malformed files / bad values become warnings
+	// surfaced on stderr so the user notices without losing the session.
+	cfg, warnings, err := config.Load(*path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "nistru: config: %v\n", err)
+		os.Exit(1)
+	}
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "nistru: config: %s: %s\n", w.Source, w.Message)
+	}
 	// Pass the ldflags-stamped Version to the autoupdate plugin *before*
 	// the editor starts. The plugin treats "dev" as "not injected" and
 	// falls back to ReadBuildInfo for `go install @tag` installs.
 	autoupdate.SetVersion(Version)
-	if err := editor.Run(*path); err != nil {
+	if err := editor.Run(*path, cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "nistru: %v\n", err)
 		os.Exit(1)
 	}

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -70,6 +70,55 @@ Plugins are **lazy**: the subprocess is only spawned when the first matching eve
 | `status-bar` | Plugin writes to the status bar |
 | `pane` | In-process only: plugin owns a layout slot |
 
+## Plugin configuration
+
+Plugins receive per-plugin config from Nistru's layered TOML file. Config lives under `[plugins.<name>]` in either:
+
+- `~/.config/nistru/config.toml` — user-wide.
+- `<root>/.nistru/config.toml` — project-local (overrides user).
+
+The `<name>` matches `Plugin.Name()`. Unknown sub-tables are kept; Nistru does not gate on schema. See [internal/config/](../internal/config/) for the merge pipeline.
+
+### Receiving config
+
+Implement the `ConfigReceiver` interface. The plugin host (in-proc) and SDK (out-of-proc) call `OnConfig` with the raw JSON bytes of the `[plugins.<name>]` sub-table before the first `Initialize`:
+
+```go
+// In-process plugin: plugin.ConfigReceiver (plugin/api.go).
+func (p *MyPlugin) OnConfig(raw json.RawMessage) error {
+    var cfg struct {
+        Enabled bool `json:"enabled"`
+    }
+    return json.Unmarshal(raw, &cfg)
+}
+```
+
+```go
+// Out-of-process plugin: plugsdk.ConfigReceiver (sdk/plugsdk/plugsdk.go).
+// plugsdk.Base provides a no-op OnConfig so embedders only override when needed.
+func (p *MyPlugin) OnConfig(raw json.RawMessage) error {
+    var cfg struct {
+        Enabled bool `json:"enabled"`
+    }
+    return json.Unmarshal(raw, &cfg)
+}
+```
+
+`raw` is `nil` when no `[plugins.<name>]` section exists. Handle `nil` as "use defaults."
+
+### When OnConfig fires
+
+1. **Once before the first `Initialize`** — in-proc, synchronously on the host goroutine; out-of-proc, injected into the spawn handshake's first Initialize frame so the SDK dispatches `OnConfig` before `OnInitialize`.
+2. **Again on every `Nistru: Reload Settings` palette invocation** — the host reparses both config files and re-emits `Initialize` to every already-activated plugin. `OnConfig` sees the fresh sub-tree each time.
+
+Errors returned from `OnConfig` are logged to stderr but non-fatal. `Initialize` still proceeds so a plugin with a malformed config section starts up with whatever state it had before the bad config was applied.
+
+### Autoupdate env vars
+
+The `autoupdate` plugin predates the config system. Its `NISTRU_AUTOUPDATE_{REPO,CHANNEL,INTERVAL,DISABLE}` env vars are kept as an emergency override path but are deprecated — prefer `[plugins.autoupdate]` in TOML.
+
+Precedence (low → high): defaults < config < env < construction-time options. The option layer exists purely as a test seam (`WithRepo`, `WithInterval`); env stays above config so a shell-level override can still unblock a user whose config is broken.
+
 ## Writing an out-of-process plugin
 
 Use the Go SDK at `github.com/savimcio/nistru/sdk/plugsdk`. Any language works over the wire, but the SDK is the shortest path.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/savimcio/nistru
 go 1.26.2
 
 require (
+	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
@@ -13,7 +14,6 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/alecthomas/chroma/v2 v2.15.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymanbagabas/go-udiff v0.3.1 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,242 @@
+// Package config defines Nistru's layered TOML configuration: built-in
+// defaults, a per-user file under <UserConfigDir>/nistru/config.toml, a
+// per-project file at <root>/.nistru/config.toml, and a whitelist of
+// NISTRU_* environment overrides (file order is lowest-to-highest
+// precedence; env beats all files). Plugin sub-tables live under
+// [plugins.<name>] and are decoded into generic maps so the loader can
+// deep-merge user → project → env per key.
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Config is the fully-merged view of Nistru's TOML configuration. It is the
+// output of Load() and the input of every subsystem that needs tunables.
+type Config struct {
+	Editor   Editor   `toml:"editor"`
+	UI       UI       `toml:"ui"`
+	Autosave Autosave `toml:"autosave"`
+	Keymap   Keymap   `toml:"keymap"`
+	Plugins  Plugins  `toml:"plugins"`
+}
+
+// Editor holds editor-wide tunables.
+type Editor struct {
+	MaxFileSize Size `toml:"max_file_size"`
+}
+
+// UI holds chrome/layout tunables.
+type UI struct {
+	TreeWidth       int           `toml:"tree_width"`
+	SavedFadeAfter  time.Duration `toml:"saved_fade_after"`
+	RelativeNumbers bool          `toml:"relative_numbers"`
+}
+
+// Autosave holds debounce knobs for the autosave subsystem.
+type Autosave struct {
+	SaveDebounce   time.Duration `toml:"save_debounce"`
+	ChangeDebounce time.Duration `toml:"change_debounce"`
+}
+
+// Plugins holds the merged [plugins.<name>] sub-trees as plain map values.
+// Each per-file decode lands in its own map[string]any; the loader
+// deep-merges them per key (project overrides user) into Merged. EnvOverlay
+// is a separate map so PluginConfig can re-merge it on top at lookup time —
+// env always wins key-by-key.
+//
+// The previous design stored BurntSushi Primitives plus the MetaData that
+// produced them, which silently broke when a plugin appeared in more than
+// one file: Primitives can only be PrimitiveDecode'd against the MetaData
+// they were parsed from, and the loader was overwriting one with the other.
+type Plugins struct {
+	Merged     map[string]map[string]any `toml:"-"`
+	EnvOverlay map[string]map[string]any `toml:"-"`
+}
+
+// Defaults returns a fully-populated *Config with Nistru's built-in
+// defaults. Plugin sub-tables are left empty — those are supplied only
+// when a user or project writes them.
+func Defaults() *Config {
+	return &Config{
+		Editor: Editor{
+			MaxFileSize: 1 << 20, // 1 MiB
+		},
+		UI: UI{
+			TreeWidth:       30,
+			SavedFadeAfter:  3 * time.Second,
+			RelativeNumbers: true,
+		},
+		Autosave: Autosave{
+			SaveDebounce:   250 * time.Millisecond,
+			ChangeDebounce: 50 * time.Millisecond,
+		},
+		Keymap: DefaultKeymap(),
+		Plugins: Plugins{
+			Merged:     map[string]map[string]any{},
+			EnvOverlay: map[string]map[string]any{},
+		},
+	}
+}
+
+// Size is a byte count that parses human-friendly TOML strings like
+// "1MiB" / "512KiB" / "2MB" (case-insensitive, binary units are 1024-based
+// and decimal units are 1000-based) or a plain integer byte count.
+type Size uint64
+
+// UnmarshalText implements encoding.TextUnmarshaler for Size.
+func (s *Size) UnmarshalText(text []byte) error {
+	raw := strings.TrimSpace(string(text))
+	if raw == "" {
+		return fmt.Errorf("config: empty size")
+	}
+	// Plain integer → bytes.
+	if n, err := strconv.ParseUint(raw, 10, 64); err == nil {
+		*s = Size(n)
+		return nil
+	}
+	// Otherwise find the longest trailing alphabetic suffix.
+	cut := len(raw)
+	for cut > 0 {
+		c := raw[cut-1]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+			cut--
+			continue
+		}
+		break
+	}
+	if cut == 0 || cut == len(raw) {
+		return fmt.Errorf("config: invalid size %q", raw)
+	}
+	numPart := strings.TrimSpace(raw[:cut])
+	suffix := strings.ToLower(strings.TrimSpace(raw[cut:]))
+	n, err := strconv.ParseUint(numPart, 10, 64)
+	if err != nil {
+		return fmt.Errorf("config: invalid size %q: %w", raw, err)
+	}
+	var mult uint64
+	switch suffix {
+	case "b":
+		mult = 1
+	case "kb":
+		mult = 1_000
+	case "mb":
+		mult = 1_000_000
+	case "gb":
+		mult = 1_000_000_000
+	case "kib":
+		mult = 1 << 10
+	case "mib":
+		mult = 1 << 20
+	case "gib":
+		mult = 1 << 30
+	default:
+		return fmt.Errorf("config: unknown size suffix %q", suffix)
+	}
+	// Guard against uint64 wrap in n*mult. mult is always >= 1 for the
+	// branches above, so the divisor is safe.
+	if n > math.MaxUint64/mult {
+		return fmt.Errorf("config: size %q overflows uint64", raw)
+	}
+	*s = Size(n * mult)
+	return nil
+}
+
+// String renders Size as a plain byte count — we don't try to guess the
+// "nicest" unit, callers that want to pretty-print should do so themselves.
+func (s Size) String() string { return strconv.FormatUint(uint64(s), 10) }
+
+// MarshalText implements encoding.TextMarshaler so Size round-trips through
+// EncodeResolved as the canonical byte count form.
+func (s Size) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+// PluginConfig returns the raw JSON bytes for plugins.<name>, or nil when
+// that plugin has neither a file entry nor an env overlay. The merged
+// file-level map is overlaid with EnvOverlay (env wins key-by-key) and the
+// result is marshaled as JSON.
+func (c *Config) PluginConfig(name string) json.RawMessage {
+	base := c.Plugins.Merged[name]
+	overlay := c.Plugins.EnvOverlay[name]
+	if len(base) == 0 && len(overlay) == 0 {
+		return nil
+	}
+	merged := make(map[string]any, len(base)+len(overlay))
+	maps.Copy(merged, base)
+	maps.Copy(merged, overlay) // env wins key-by-key
+	b, err := json.Marshal(merged)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// EncodeResolved dumps the fully-merged Config back to TOML. Plugin
+// sub-tables come straight from the merged + env-overlaid view that
+// PluginConfig returns; we deliberately re-do the merge here rather than
+// calling json.Marshal/Unmarshal so int and bool values survive as TOML
+// integers/booleans rather than being coerced to JSON numbers. Used by the
+// `showResolved` palette command so users can see exactly what the editor
+// computed.
+func (c *Config) EncodeResolved() ([]byte, error) {
+	type resolved struct {
+		Editor   Editor                    `toml:"editor"`
+		UI       UI                        `toml:"ui"`
+		Autosave Autosave                  `toml:"autosave"`
+		Keymap   map[string]string         `toml:"keymap"`
+		Plugins  map[string]map[string]any `toml:"plugins,omitempty"`
+	}
+	km := make(map[string]string, len(c.Keymap))
+	for a, v := range c.Keymap {
+		km[string(a)] = v
+	}
+	r := resolved{
+		Editor:   c.Editor,
+		UI:       c.UI,
+		Autosave: c.Autosave,
+		Keymap:   km,
+	}
+	if len(c.Plugins.Merged) > 0 || len(c.Plugins.EnvOverlay) > 0 {
+		// Collect every plugin name that appears in either map so plugins
+		// that are env-only (no file entry) still show up in the dump.
+		names := map[string]struct{}{}
+		for name := range c.Plugins.Merged {
+			names[name] = struct{}{}
+		}
+		for name := range c.Plugins.EnvOverlay {
+			names[name] = struct{}{}
+		}
+		r.Plugins = map[string]map[string]any{}
+		for name := range names {
+			base := c.Plugins.Merged[name]
+			overlay := c.Plugins.EnvOverlay[name]
+			if len(base) == 0 && len(overlay) == 0 {
+				continue
+			}
+			m := make(map[string]any, len(base)+len(overlay))
+			maps.Copy(m, base)
+			maps.Copy(m, overlay)
+			if len(m) > 0 {
+				r.Plugins[name] = m
+			}
+		}
+		if len(r.Plugins) == 0 {
+			r.Plugins = nil
+		}
+	}
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(r); err != nil {
+		return nil, fmt.Errorf("config: encode resolved: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,224 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestDefaultsFullyPopulated(t *testing.T) {
+	c := Defaults()
+	if c == nil {
+		t.Fatal("Defaults() returned nil")
+	}
+	if c.Editor.MaxFileSize != 1<<20 {
+		t.Errorf("Editor.MaxFileSize = %d, want %d", c.Editor.MaxFileSize, 1<<20)
+	}
+	if c.UI.TreeWidth != 30 {
+		t.Errorf("UI.TreeWidth = %d, want 30", c.UI.TreeWidth)
+	}
+	if c.UI.SavedFadeAfter != 3*time.Second {
+		t.Errorf("UI.SavedFadeAfter = %v, want 3s", c.UI.SavedFadeAfter)
+	}
+	if !c.UI.RelativeNumbers {
+		t.Error("UI.RelativeNumbers should default true")
+	}
+	if c.Autosave.SaveDebounce != 250*time.Millisecond {
+		t.Errorf("Autosave.SaveDebounce = %v, want 250ms", c.Autosave.SaveDebounce)
+	}
+	if c.Autosave.ChangeDebounce != 50*time.Millisecond {
+		t.Errorf("Autosave.ChangeDebounce = %v, want 50ms", c.Autosave.ChangeDebounce)
+	}
+	if len(c.Keymap) != len(knownActions) {
+		t.Errorf("Keymap has %d entries, want %d", len(c.Keymap), len(knownActions))
+	}
+	for _, a := range knownActions {
+		if v, ok := c.Keymap[a]; !ok || v == "" {
+			t.Errorf("Keymap[%q] missing or empty", a)
+		}
+	}
+	if c.Plugins.Merged == nil {
+		t.Error("Plugins.Merged should be non-nil on defaults")
+	}
+	if c.Plugins.EnvOverlay == nil {
+		t.Error("Plugins.EnvOverlay should be non-nil on defaults")
+	}
+}
+
+func TestSizeUnmarshalText(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  Size
+		isErr bool
+	}{
+		{"0", 0, false},
+		{"1024", 1024, false},
+		{"1KiB", 1024, false},
+		{"1kib", 1024, false},
+		{"1MiB", 1 << 20, false},
+		{"2MiB", 2 << 20, false},
+		{"1GiB", 1 << 30, false},
+		{"1KB", 1_000, false},
+		{"2MB", 2_000_000, false},
+		{"1GB", 1_000_000_000, false},
+		{"512B", 512, false},
+		{"", 0, true},
+		{"abc", 0, true},
+		{"1XB", 0, true},
+		{"MiB", 0, true},
+		{"-1MiB", 0, true},
+		// Overflow: n * mult would wrap uint64. Must error instead of
+		// silently producing a tiny byte count. math.MaxUint64 is
+		// 18446744073709551615; multiplying any of those by >=2 overflows.
+		{"18446744073709551615KiB", 0, true},
+		{"99999999999999999GiB", 0, true},
+	}
+	for _, tc := range cases {
+		var s Size
+		err := s.UnmarshalText([]byte(tc.in))
+		if tc.isErr {
+			if err == nil {
+				t.Errorf("Size(%q) expected error, got %d", tc.in, s)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Size(%q) unexpected err: %v", tc.in, err)
+			continue
+		}
+		if s != tc.want {
+			t.Errorf("Size(%q) = %d, want %d", tc.in, uint64(s), uint64(tc.want))
+		}
+	}
+}
+
+func TestPluginConfigRoundTrip(t *testing.T) {
+	c := Defaults()
+	c.Plugins.Merged["autoupdate"] = map[string]any{
+		"repo":     "savimcio/nistru",
+		"channel":  "release",
+		"interval": "1h",
+		"disable":  false,
+	}
+
+	raw := c.PluginConfig("autoupdate")
+	if raw == nil {
+		t.Fatal("PluginConfig returned nil for known plugin")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["repo"] != "savimcio/nistru" {
+		t.Errorf("repo = %v", got["repo"])
+	}
+	if got["channel"] != "release" {
+		t.Errorf("channel = %v", got["channel"])
+	}
+	if got["disable"] != false {
+		t.Errorf("disable = %v", got["disable"])
+	}
+
+	// Unknown plugin returns nil.
+	if c.PluginConfig("nope") != nil {
+		t.Errorf("PluginConfig(nope) should be nil")
+	}
+}
+
+func TestPluginConfigMergesEnvOverlay(t *testing.T) {
+	c := Defaults()
+	c.Plugins.Merged["autoupdate"] = map[string]any{
+		"repo": "savimcio/nistru",
+	}
+	c.Plugins.EnvOverlay["autoupdate"] = map[string]any{
+		"repo":    "override/repo",
+		"disable": true,
+	}
+
+	raw := c.PluginConfig("autoupdate")
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["repo"] != "override/repo" {
+		t.Errorf("overlay didn't win: repo=%v", got["repo"])
+	}
+	if got["disable"] != true {
+		t.Errorf("overlay key missing: disable=%v", got["disable"])
+	}
+}
+
+func TestPluginConfigOverlayOnlyNoFile(t *testing.T) {
+	c := Defaults()
+	c.Plugins.EnvOverlay["autoupdate"] = map[string]any{"repo": "x/y"}
+	raw := c.PluginConfig("autoupdate")
+	if raw == nil {
+		t.Fatal("overlay-only should still yield JSON")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["repo"] != "x/y" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestEncodeResolvedParses(t *testing.T) {
+	c := Defaults()
+	b, err := c.EncodeResolved()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if len(b) == 0 {
+		t.Fatal("empty encode")
+	}
+	// Round-trip: parse back into a fresh struct that mirrors the schema.
+	var back struct {
+		Editor   Editor
+		UI       UI
+		Autosave Autosave
+		Keymap   map[string]string
+	}
+	if _, err := toml.Decode(string(b), &back); err != nil {
+		t.Fatalf("reparse: %v\nOUTPUT:\n%s", err, b)
+	}
+	if back.UI.TreeWidth != 30 {
+		t.Errorf("round-tripped TreeWidth = %d", back.UI.TreeWidth)
+	}
+}
+
+// TestEncodeResolvedIncludesPlugins guards that EncodeResolved emits the
+// merged + env-overlaid plugins section so `showResolved` doesn't lie.
+func TestEncodeResolvedIncludesPlugins(t *testing.T) {
+	c := Defaults()
+	c.Plugins.Merged["autoupdate"] = map[string]any{
+		"repo":    "u/r",
+		"channel": "release",
+	}
+	c.Plugins.EnvOverlay["autoupdate"] = map[string]any{
+		"repo": "env/wins",
+	}
+	b, err := c.EncodeResolved()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	var back struct {
+		Plugins map[string]map[string]any `toml:"plugins"`
+	}
+	if _, err := toml.Decode(string(b), &back); err != nil {
+		t.Fatalf("reparse: %v\nOUTPUT:\n%s", err, b)
+	}
+	au, ok := back.Plugins["autoupdate"]
+	if !ok {
+		t.Fatalf("autoupdate missing from resolved plugins: %s", b)
+	}
+	if au["repo"] != "env/wins" {
+		t.Errorf("env didn't win in EncodeResolved: %v", au["repo"])
+	}
+	if au["channel"] != "release" {
+		t.Errorf("file key lost in EncodeResolved: %v", au["channel"])
+	}
+}

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// applyEnv applies the whitelist of NISTRU_* environment variables to cfg.
+// Env beats every file-level setting. Only variables in the whitelist are
+// honored; anything else in the environment is ignored. Plugin-bound
+// overrides are written into cfg.Plugins.EnvOverlay so PluginConfig can
+// merge them over the file-derived JSON at lookup time.
+func applyEnv(cfg *Config) []Warning {
+	var warnings []Warning
+	if cfg.Plugins.EnvOverlay == nil {
+		cfg.Plugins.EnvOverlay = map[string]map[string]any{}
+	}
+
+	// autoupdate plugin — these must keep working after the plugin migrates
+	// off os.Getenv onto PluginConfig. Empty strings count as "unset"
+	// across the board: a shell that exports NISTRU_AUTOUPDATE_FOO= should
+	// not override a file value with "".
+	if v, ok := lookup("NISTRU_AUTOUPDATE_REPO"); ok && v != "" {
+		pluginSet(cfg, "autoupdate", "repo", v)
+	}
+	if v, ok := lookup("NISTRU_AUTOUPDATE_CHANNEL"); ok && v != "" {
+		pluginSet(cfg, "autoupdate", "channel", v)
+	}
+	if v, ok := lookup("NISTRU_AUTOUPDATE_INTERVAL"); ok && v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			warnings = append(warnings, Warning{
+				Source:  "env",
+				Message: fmt.Sprintf("NISTRU_AUTOUPDATE_INTERVAL=%q is not a valid duration: %v", v, err),
+			})
+		} else {
+			pluginSet(cfg, "autoupdate", "interval", d.String())
+		}
+	}
+	if v, ok := lookup("NISTRU_AUTOUPDATE_DISABLE"); ok {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "1", "true", "yes":
+			pluginSet(cfg, "autoupdate", "disable", true)
+		case "":
+			// empty = unset; nothing to do
+		case "0", "false", "no":
+			pluginSet(cfg, "autoupdate", "disable", false)
+		default:
+			warnings = append(warnings, Warning{
+				Source:  "env",
+				Message: fmt.Sprintf("NISTRU_AUTOUPDATE_DISABLE=%q is not a recognized bool", v),
+			})
+		}
+	}
+	return warnings
+}
+
+// lookup is a thin wrapper around os.LookupEnv so env.go has exactly one
+// point of contact with the environment — simpler to audit and stub.
+func lookup(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
+// pluginSet stores a single field override into the plugin-env overlay.
+func pluginSet(cfg *Config, name, key string, value any) {
+	m, ok := cfg.Plugins.EnvOverlay[name]
+	if !ok {
+		m = map[string]any{}
+		cfg.Plugins.EnvOverlay[name] = m
+	}
+	m[key] = value
+}

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"testing"
+)
+
+func newCfgForEnv() *Config {
+	c := Defaults()
+	// Empty plugin overlays so tests see only what applyEnv wrote.
+	c.Plugins.EnvOverlay = map[string]map[string]any{}
+	return c
+}
+
+func TestEnvRepo(t *testing.T) {
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "foo/bar")
+	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "")
+	c := newCfgForEnv()
+	if ws := applyEnv(c); len(ws) != 0 {
+		t.Errorf("unexpected warnings: %+v", ws)
+	}
+	if c.Plugins.EnvOverlay["autoupdate"]["repo"] != "foo/bar" {
+		t.Errorf("repo overlay = %v", c.Plugins.EnvOverlay["autoupdate"])
+	}
+}
+
+func TestEnvChannel(t *testing.T) {
+	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "dev")
+	c := newCfgForEnv()
+	applyEnv(c)
+	if c.Plugins.EnvOverlay["autoupdate"]["channel"] != "dev" {
+		t.Errorf("channel overlay = %v", c.Plugins.EnvOverlay["autoupdate"])
+	}
+}
+
+func TestEnvInterval(t *testing.T) {
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "30m")
+	c := newCfgForEnv()
+	ws := applyEnv(c)
+	if len(ws) != 0 {
+		t.Errorf("warnings: %+v", ws)
+	}
+	got := c.Plugins.EnvOverlay["autoupdate"]["interval"]
+	if got != "30m0s" && got != "30m" {
+		t.Errorf("interval = %v", got)
+	}
+}
+
+func TestEnvIntervalBadValue(t *testing.T) {
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "not-a-duration")
+	c := newCfgForEnv()
+	ws := applyEnv(c)
+	if len(ws) == 0 {
+		t.Error("expected a warning for bad interval")
+	}
+	if _, present := c.Plugins.EnvOverlay["autoupdate"]["interval"]; present {
+		t.Errorf("bad interval should not be written")
+	}
+}
+
+func TestEnvDisableTrueVariants(t *testing.T) {
+	for _, v := range []string{"1", "true", "TRUE", "yes", "YES"} {
+		t.Setenv("NISTRU_AUTOUPDATE_DISABLE", v)
+		c := newCfgForEnv()
+		ws := applyEnv(c)
+		if len(ws) != 0 {
+			t.Errorf("warnings for %q: %+v", v, ws)
+		}
+		if c.Plugins.EnvOverlay["autoupdate"]["disable"] != true {
+			t.Errorf("DISABLE=%q didn't set true: %v", v, c.Plugins.EnvOverlay["autoupdate"])
+		}
+	}
+}
+
+func TestEnvDisableFalseVariants(t *testing.T) {
+	for _, v := range []string{"0", "false", "no"} {
+		t.Setenv("NISTRU_AUTOUPDATE_DISABLE", v)
+		c := newCfgForEnv()
+		applyEnv(c)
+		if c.Plugins.EnvOverlay["autoupdate"]["disable"] != false {
+			t.Errorf("DISABLE=%q didn't set false: %v", v, c.Plugins.EnvOverlay["autoupdate"])
+		}
+	}
+}
+
+func TestEnvDisableEmptyIsNoOp(t *testing.T) {
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "")
+	c := newCfgForEnv()
+	applyEnv(c)
+	if _, present := c.Plugins.EnvOverlay["autoupdate"]["disable"]; present {
+		t.Error("empty DISABLE should be a no-op")
+	}
+}
+
+func TestEnvDisableUnknownWarns(t *testing.T) {
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "maybe")
+	c := newCfgForEnv()
+	ws := applyEnv(c)
+	if len(ws) == 0 {
+		t.Error("expected warning for unrecognized bool")
+	}
+}
+
+func TestEnvAllUnsetIsNoOp(t *testing.T) {
+	for _, k := range []string{
+		"NISTRU_AUTOUPDATE_REPO",
+		"NISTRU_AUTOUPDATE_CHANNEL",
+		"NISTRU_AUTOUPDATE_INTERVAL",
+		"NISTRU_AUTOUPDATE_DISABLE",
+	} {
+		t.Setenv(k, "")
+		// t.Setenv to "" still counts as set; explicitly unset below.
+	}
+	// Force-unset so lookup returns (_, false).
+	for _, k := range []string{
+		"NISTRU_AUTOUPDATE_REPO",
+		"NISTRU_AUTOUPDATE_CHANNEL",
+		"NISTRU_AUTOUPDATE_INTERVAL",
+		"NISTRU_AUTOUPDATE_DISABLE",
+	} {
+		// Use Setenv('') then Unsetenv via os
+		unsetEnv(t, k)
+	}
+	c := newCfgForEnv()
+	ws := applyEnv(c)
+	if len(ws) != 0 {
+		t.Errorf("warnings: %+v", ws)
+	}
+	if _, present := c.Plugins.EnvOverlay["autoupdate"]; present {
+		t.Errorf("overlay should be empty: %v", c.Plugins.EnvOverlay["autoupdate"])
+	}
+}

--- a/internal/config/env_testhelper_test.go
+++ b/internal/config/env_testhelper_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// unsetEnv unsets key for the duration of the test. t.Setenv only supports
+// "set to empty"; for our applyEnv logic we need to exercise the false
+// branch of os.LookupEnv, which requires an actual Unsetenv.
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unsetenv %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}

--- a/internal/config/keymap.go
+++ b/internal/config/keymap.go
@@ -1,0 +1,154 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Action enumerates the editor commands that can be bound to a key.
+type Action string
+
+const (
+	ActionSave      Action = "save"
+	ActionQuit      Action = "quit"
+	ActionPalette   Action = "palette"
+	ActionFocusNext Action = "focus_next"
+	ActionFocusPrev Action = "focus_prev"
+	ActionUndo      Action = "undo"
+	ActionRedo      Action = "redo"
+	ActionCutLine   Action = "cut_line"
+	ActionCopyLine  Action = "copy_line"
+	ActionPaste     Action = "paste"
+)
+
+// Keymap maps actions to their bound key string (bubbletea KeyMsg.String()
+// form, e.g. "ctrl+s", "shift+tab"). It is NOT validated against the full
+// bubbletea key vocabulary — that list is open-ended and using a whitelist
+// would produce spurious warnings. Only structural problems (unknown
+// actions, empty strings, duplicates) are flagged.
+type Keymap map[Action]string
+
+// knownActions is the canonical list of actions in their stable source
+// order — used for duplicate detection (earlier declaration wins).
+var knownActions = []Action{
+	ActionSave, ActionQuit, ActionPalette,
+	ActionFocusNext, ActionFocusPrev,
+	ActionUndo, ActionRedo,
+	ActionCutLine, ActionCopyLine, ActionPaste,
+}
+
+// DefaultKeymap returns the built-in default bindings.
+func DefaultKeymap() Keymap {
+	return Keymap{
+		ActionSave:      "ctrl+s",
+		ActionQuit:      "ctrl+q",
+		ActionPalette:   "ctrl+p",
+		ActionFocusNext: "tab",
+		ActionFocusPrev: "shift+tab",
+		ActionUndo:      "ctrl+z",
+		ActionRedo:      "ctrl+y",
+		ActionCutLine:   "ctrl+x",
+		ActionCopyLine:  "ctrl+c",
+		ActionPaste:     "ctrl+v",
+	}
+}
+
+// isKnownAction reports whether a is a declared Action.
+func isKnownAction(a Action) bool {
+	for _, k := range knownActions {
+		if k == a {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate mutates the receiver in place to resolve structural problems
+// and returns a slice of human-readable warnings:
+//
+//   - Unknown actions (keys that don't match any Action constant) are
+//     dropped.
+//   - Empty bindings fall back to the default for that action.
+//   - Duplicate bindings (two actions sharing the same key) fall back on
+//     the later-declared action. If the fallback ALSO conflicts with an
+//     earlier mapping, the later binding is kept as-is — we'd rather
+//     leave a conflict in place than silently lose a binding.
+func (k Keymap) Validate() []Warning {
+	if k == nil {
+		return nil
+	}
+	var warnings []Warning
+
+	// Drop unknown actions first — deterministic order for test stability.
+	unknown := make([]string, 0)
+	for a := range k {
+		if !isKnownAction(a) {
+			unknown = append(unknown, string(a))
+		}
+	}
+	sort.Strings(unknown)
+	for _, u := range unknown {
+		warnings = append(warnings, Warning{
+			Source:  "keymap",
+			Message: fmt.Sprintf("unknown action %q (dropped)", u),
+		})
+		delete(k, Action(u))
+	}
+
+	defaults := DefaultKeymap()
+
+	// Empty bindings → fall back to default.
+	for _, a := range knownActions {
+		if v, ok := k[a]; ok && v == "" {
+			warnings = append(warnings, Warning{
+				Source:  "keymap",
+				Message: fmt.Sprintf("empty binding for %q (using default %q)", a, defaults[a]),
+			})
+			k[a] = defaults[a]
+		}
+	}
+
+	// Duplicate detection walks actions in declaration order. The first to
+	// claim a key keeps it; later ones are bumped back to their default.
+	claimed := map[string]Action{}
+	for _, a := range knownActions {
+		v, ok := k[a]
+		if !ok {
+			continue
+		}
+		if prev, taken := claimed[v]; taken {
+			// Tie-break: try the default for the losing action. If that
+			// default is also taken, keep the current value (document the
+			// conflict; don't lose the binding).
+			fallback := defaults[a]
+			if _, taken2 := claimed[fallback]; taken2 || fallback == v {
+				warnings = append(warnings, Warning{
+					Source:  "keymap",
+					Message: fmt.Sprintf("duplicate binding %q (actions %q and %q share it; keeping %q)", v, prev, a, a),
+				})
+				claimed[v] = a
+				continue
+			}
+			warnings = append(warnings, Warning{
+				Source:  "keymap",
+				Message: fmt.Sprintf("duplicate binding %q (actions %q and %q share it; %q falls back to %q)", v, prev, a, a, fallback),
+			})
+			k[a] = fallback
+			claimed[fallback] = a
+			continue
+		}
+		claimed[v] = a
+	}
+	return warnings
+}
+
+// Lookup returns the binding for a, or the built-in default when the
+// receiver has no entry (e.g. after Validate dropped a broken one).
+func (k Keymap) Lookup(a Action) string {
+	if k != nil {
+		if v, ok := k[a]; ok && v != "" {
+			return v
+		}
+	}
+	return DefaultKeymap()[a]
+}

--- a/internal/config/keymap_test.go
+++ b/internal/config/keymap_test.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultKeymapAllActions(t *testing.T) {
+	km := DefaultKeymap()
+	for _, a := range knownActions {
+		if km[a] == "" {
+			t.Errorf("DefaultKeymap missing %q", a)
+		}
+	}
+}
+
+func TestKeymapValidateUnknownActionDropped(t *testing.T) {
+	km := DefaultKeymap()
+	km["does_not_exist"] = "ctrl+f"
+	warnings := km.Validate()
+	if len(warnings) == 0 {
+		t.Fatal("expected warning for unknown action")
+	}
+	if _, still := km["does_not_exist"]; still {
+		t.Error("unknown action should be dropped")
+	}
+	if !strings.Contains(warnings[0].Message, "unknown action") {
+		t.Errorf("warning text: %q", warnings[0].Message)
+	}
+}
+
+func TestKeymapValidateEmptyBindingFallsBack(t *testing.T) {
+	km := DefaultKeymap()
+	km[ActionSave] = ""
+	warnings := km.Validate()
+	if len(warnings) == 0 {
+		t.Fatal("expected warning for empty binding")
+	}
+	if km[ActionSave] != "ctrl+s" {
+		t.Errorf("empty save didn't fall back to default: %q", km[ActionSave])
+	}
+}
+
+func TestKeymapValidateDuplicateBinding(t *testing.T) {
+	km := DefaultKeymap()
+	// Force a conflict between save and quit.
+	km[ActionQuit] = "ctrl+s"
+	warnings := km.Validate()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w.Message, "duplicate binding") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate-binding warning, got %+v", warnings)
+	}
+	// Save was declared first among knownActions, so it wins the original
+	// "ctrl+s". Quit falls back to the default "ctrl+q".
+	if km[ActionSave] != "ctrl+s" {
+		t.Errorf("save should have kept ctrl+s, got %q", km[ActionSave])
+	}
+	if km[ActionQuit] != "ctrl+q" {
+		t.Errorf("quit should have fallen back to ctrl+q, got %q", km[ActionQuit])
+	}
+}
+
+func TestKeymapValidateDuplicateFallbackAlsoTaken(t *testing.T) {
+	// Construct a scenario where the fallback default is itself already
+	// claimed. Per inline tie-break: keep the later binding in place.
+	km := Keymap{
+		ActionSave:    "ctrl+q", // collides with default for quit; save's default is ctrl+s
+		ActionQuit:    "ctrl+s", // collides with default for save; quit's default is ctrl+q, which save now holds
+		ActionPalette: "ctrl+p",
+	}
+	// After walk: save claims ctrl+q. quit's ctrl+s is not yet claimed, so
+	// this specific case doesn't exercise "fallback also taken" — let's pick
+	// a harsher construction.
+	km = Keymap{
+		ActionSave:    "ctrl+s",
+		ActionQuit:    "ctrl+s", // duplicate; fallback=ctrl+q
+		ActionPalette: "ctrl+q", // also taken (or will be)
+	}
+	warnings := km.Validate()
+	if len(warnings) == 0 {
+		t.Fatal("expected warnings")
+	}
+	// The point: no silent data loss — save still has ctrl+s.
+	if km[ActionSave] != "ctrl+s" {
+		t.Errorf("save lost binding: %q", km[ActionSave])
+	}
+}
+
+func TestKeymapLookupFallsBackToDefault(t *testing.T) {
+	km := Keymap{}
+	if got := km.Lookup(ActionSave); got != "ctrl+s" {
+		t.Errorf("Lookup(save) = %q, want ctrl+s (default)", got)
+	}
+}
+
+func TestKeymapLookupUsesCustom(t *testing.T) {
+	km := Keymap{ActionSave: "alt+s"}
+	if got := km.Lookup(ActionSave); got != "alt+s" {
+		t.Errorf("Lookup(save) = %q, want alt+s", got)
+	}
+}
+
+func TestKeymapLookupNilReceiver(t *testing.T) {
+	var km Keymap
+	if got := km.Lookup(ActionQuit); got != "ctrl+q" {
+		t.Errorf("nil Lookup(quit) = %q, want ctrl+q", got)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Warning is a non-fatal complaint surfaced to the user — a bad value in
+// config, a malformed file on disk, an env var that couldn't be parsed.
+// The editor stays up no matter how many warnings pile up; only
+// truly-unrecoverable problems (e.g. a nil Config pointer) become errors.
+type Warning struct {
+	Source  string
+	Message string
+}
+
+// Load resolves Nistru's configuration for the given project root.
+// Precedence (lowest to highest): built-in defaults → per-user file →
+// per-project file → NISTRU_* environment overrides. Missing files are
+// not warnings; malformed files are warnings, and whatever state was
+// parsed before the first syntax error is still applied (same discipline
+// autoupdate.LoadState uses for its JSON state file). Hard errors are
+// reserved for situations that leave us with no usable Config at all.
+func Load(root string) (*Config, []Warning, error) {
+	cfg := Defaults()
+	var warnings []Warning
+
+	// 1. User file.
+	userPath, err := UserPath()
+	if err != nil {
+		warnings = append(warnings, Warning{Source: "paths", Message: err.Error()})
+	} else if lerr := decodeInto(userPath, cfg); lerr != nil {
+		warnings = append(warnings, Warning{
+			Source:  userPath,
+			Message: fmt.Sprintf("skipped: %v", lerr),
+		})
+	}
+
+	// 2. Project file. decodeInto deep-merges plugin sub-tables on top of
+	//    whatever the user file installed, key-by-key.
+	projPath := ProjectPath(root)
+	if lerr := decodeInto(projPath, cfg); lerr != nil {
+		warnings = append(warnings, Warning{
+			Source:  projPath,
+			Message: fmt.Sprintf("skipped: %v", lerr),
+		})
+	}
+
+	// 3. Env overrides — always applied last so they beat both files.
+	warnings = append(warnings, applyEnv(cfg)...)
+
+	// 4. Keymap structural validation.
+	warnings = append(warnings, cfg.Keymap.Validate()...)
+
+	return cfg, warnings, nil
+}
+
+// decodeInto reads a TOML file into cfg. A missing file is a no-op (returns
+// nil). A malformed file returns the decode error so Load can convert it
+// into a Warning. Plugin sub-tables are deep-merged into cfg.Plugins.Merged
+// per key — each file decodes its [plugins.<name>] tables into a fresh
+// map[string]any, and mergeMap walks the result so nested tables compose
+// rather than clobber.
+func decodeInto(path string, cfg *Config) error {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	type shadow struct {
+		Editor   *Editor                   `toml:"editor,omitempty"`
+		UI       *UI                       `toml:"ui,omitempty"`
+		Autosave *Autosave                 `toml:"autosave,omitempty"`
+		Keymap   Keymap                    `toml:"keymap,omitempty"`
+		Plugins  map[string]map[string]any `toml:"plugins,omitempty"`
+	}
+	var sh shadow
+	md, err := toml.DecodeFile(path, &sh)
+	if err != nil {
+		return err
+	}
+
+	// Scalar-level merge: only overwrite fields the file actually set.
+	// BurntSushi's IsDefined lets us distinguish "present with zero value"
+	// from "absent" so a user can't clobber a default by accident.
+	if md.IsDefined("editor", "max_file_size") && sh.Editor != nil {
+		cfg.Editor.MaxFileSize = sh.Editor.MaxFileSize
+	}
+	if sh.UI != nil {
+		if md.IsDefined("ui", "tree_width") {
+			cfg.UI.TreeWidth = sh.UI.TreeWidth
+		}
+		if md.IsDefined("ui", "saved_fade_after") {
+			cfg.UI.SavedFadeAfter = sh.UI.SavedFadeAfter
+		}
+		if md.IsDefined("ui", "relative_numbers") {
+			cfg.UI.RelativeNumbers = sh.UI.RelativeNumbers
+		}
+	}
+	if sh.Autosave != nil {
+		if md.IsDefined("autosave", "save_debounce") {
+			cfg.Autosave.SaveDebounce = sh.Autosave.SaveDebounce
+		}
+		if md.IsDefined("autosave", "change_debounce") {
+			cfg.Autosave.ChangeDebounce = sh.Autosave.ChangeDebounce
+		}
+	}
+	if sh.Keymap != nil {
+		if cfg.Keymap == nil {
+			cfg.Keymap = Keymap{}
+		}
+		for action, binding := range sh.Keymap {
+			cfg.Keymap[action] = binding
+		}
+	}
+	if len(sh.Plugins) > 0 {
+		if cfg.Plugins.Merged == nil {
+			cfg.Plugins.Merged = map[string]map[string]any{}
+		}
+		for name, src := range sh.Plugins {
+			dst, ok := cfg.Plugins.Merged[name]
+			if !ok {
+				dst = map[string]any{}
+				cfg.Plugins.Merged[name] = dst
+			}
+			mergeMap(dst, src)
+		}
+	}
+	return nil
+}
+
+// mergeMap copies src into dst with per-key override semantics. Nested
+// tables (map[string]any) recurse so a project file that only sets one
+// inner key doesn't wipe its siblings. Arrays and scalars replace
+// wholesale — Kitty-style predictability, no implicit concatenation.
+func mergeMap(dst, src map[string]any) {
+	for k, v := range src {
+		if sub, ok := v.(map[string]any); ok {
+			if existing, ok := dst[k].(map[string]any); ok {
+				mergeMap(existing, sub)
+				continue
+			}
+			// Either dst has no value, or its value is not a table; in
+			// both cases the source table wins outright. Copy into a
+			// fresh map so future merges into dst don't mutate src.
+			fresh := make(map[string]any, len(sub))
+			mergeMap(fresh, sub)
+			dst[k] = fresh
+			continue
+		}
+		dst[k] = v
+	}
+}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,0 +1,388 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// setupIsolatedHome points os.UserConfigDir() at a fresh temp dir by
+// rewriting every env var UserConfigDir consults (Linux uses
+// XDG_CONFIG_HOME, macOS uses HOME, Windows uses APPDATA). Returns the
+// resolved user config path so tests can write fixture files to the
+// exact place Load() will look. Also clears every NISTRU_AUTOUPDATE_*
+// env var so stale values in the caller's shell don't leak in.
+func setupIsolatedHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", home)
+	t.Setenv("HOME", home)
+	t.Setenv("AppData", home)
+	for _, k := range []string{
+		"NISTRU_AUTOUPDATE_REPO",
+		"NISTRU_AUTOUPDATE_CHANNEL",
+		"NISTRU_AUTOUPDATE_INTERVAL",
+		"NISTRU_AUTOUPDATE_DISABLE",
+	} {
+		unsetEnv(t, k)
+	}
+	userPath, err := UserPath()
+	if err != nil {
+		t.Fatalf("UserPath after isolation: %v", err)
+	}
+	return userPath
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestLoadDefaultsOnly(t *testing.T) {
+	_ = setupIsolatedHome(t)
+	projRoot := t.TempDir()
+	c, warnings, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %+v", warnings)
+	}
+	if c.UI.TreeWidth != 30 {
+		t.Errorf("TreeWidth = %d", c.UI.TreeWidth)
+	}
+}
+
+func TestLoadUserOverridesDefaults(t *testing.T) {
+	userCfg := setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, userCfg, `
+[ui]
+tree_width = 99
+`)
+	c, warnings, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("warnings: %+v", warnings)
+	}
+	if c.UI.TreeWidth != 99 {
+		t.Errorf("TreeWidth = %d, want 99", c.UI.TreeWidth)
+	}
+	// Untouched defaults survive.
+	if c.UI.SavedFadeAfter != 3*time.Second {
+		t.Errorf("SavedFadeAfter = %v", c.UI.SavedFadeAfter)
+	}
+}
+
+func TestLoadProjectOverridesUser(t *testing.T) {
+	userCfg := setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, userCfg, `
+[ui]
+tree_width = 10
+saved_fade_after = "1s"
+`)
+	writeFile(t, ProjectPath(projRoot), `
+[ui]
+tree_width = 20
+`)
+	c, warnings, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("warnings: %+v", warnings)
+	}
+	if c.UI.TreeWidth != 20 {
+		t.Errorf("project didn't override user: TreeWidth = %d", c.UI.TreeWidth)
+	}
+	// Keys the project file doesn't touch come from the user file.
+	if c.UI.SavedFadeAfter != time.Second {
+		t.Errorf("SavedFadeAfter = %v, want 1s", c.UI.SavedFadeAfter)
+	}
+}
+
+func TestLoadEnvOverridesProject(t *testing.T) {
+	_ = setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, ProjectPath(projRoot), `
+[plugins.autoupdate]
+repo = "fromfile/proj"
+channel = "release"
+`)
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "fromenv/override")
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "true")
+
+	c, _, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	raw := c.PluginConfig("autoupdate")
+	if raw == nil {
+		t.Fatal("PluginConfig is nil")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["repo"] != "fromenv/override" {
+		t.Errorf("env didn't beat file: repo=%v", got["repo"])
+	}
+	if got["disable"] != true {
+		t.Errorf("env bool missing: disable=%v", got["disable"])
+	}
+	// Unrelated file keys survive.
+	if got["channel"] != "release" {
+		t.Errorf("file channel lost: channel=%v", got["channel"])
+	}
+}
+
+func TestLoadMalformedTOMLIsWarning(t *testing.T) {
+	_ = setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, ProjectPath(projRoot), `this is = not = valid toml`)
+	c, warnings, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load error (should have been a warning): %v", err)
+	}
+	if c == nil {
+		t.Fatal("cfg was nil despite malformed project file")
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w.Message, "skipped") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected malformed-file warning; got %+v", warnings)
+	}
+	// Defaults still in force.
+	if c.UI.TreeWidth != 30 {
+		t.Errorf("TreeWidth = %d", c.UI.TreeWidth)
+	}
+}
+
+// TestPluginConfig_MergesUserAndProject is the bug fix: when each file
+// sets a different key under the same plugin, both must survive the merge.
+// The old Primitive-based design clobbered cfg.Plugins.Raw[name] from the
+// later file, losing the earlier file's keys silently.
+func TestPluginConfig_MergesUserAndProject(t *testing.T) {
+	userCfg := setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, userCfg, `
+[plugins.autoupdate]
+repo = "u/r"
+`)
+	writeFile(t, ProjectPath(projRoot), `
+[plugins.autoupdate]
+interval = "2h"
+`)
+	c, _, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	raw := c.PluginConfig("autoupdate")
+	if raw == nil {
+		t.Fatal("PluginConfig is nil after cross-file merge")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["repo"] != "u/r" {
+		t.Errorf("user-only key lost: repo=%v (full=%v)", got["repo"], got)
+	}
+	if got["interval"] != "2h" {
+		t.Errorf("project-only key lost: interval=%v (full=%v)", got["interval"], got)
+	}
+}
+
+func TestPluginConfig_ProjectOverridesUser_PerKey(t *testing.T) {
+	userCfg := setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, userCfg, `
+[plugins.autoupdate]
+repo = "user/wins"
+channel = "release"
+`)
+	writeFile(t, ProjectPath(projRoot), `
+[plugins.autoupdate]
+repo = "proj/wins"
+`)
+	c, _, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(c.PluginConfig("autoupdate"), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["repo"] != "proj/wins" {
+		t.Errorf("project should win on shared key: repo=%v", got["repo"])
+	}
+	if got["channel"] != "release" {
+		t.Errorf("user-only key lost: channel=%v", got["channel"])
+	}
+}
+
+func TestPluginConfig_ArrayReplacesWholesale(t *testing.T) {
+	userCfg := setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, userCfg, `
+[plugins.treepane]
+skip_dirs = ["a"]
+`)
+	writeFile(t, ProjectPath(projRoot), `
+[plugins.treepane]
+skip_dirs = ["b"]
+`)
+	c, _, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(c.PluginConfig("treepane"), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	dirs, ok := got["skip_dirs"].([]any)
+	if !ok {
+		t.Fatalf("skip_dirs not a slice: %T", got["skip_dirs"])
+	}
+	if len(dirs) != 1 || dirs[0] != "b" {
+		t.Errorf("array should replace wholesale, got %v", dirs)
+	}
+}
+
+// TestPluginConfig_PluginOnlyInUser is the regression guard for the
+// MetaData-mismatch bug: when a plugin appears only in the user file,
+// later files (project) used to install their own MetaData onto
+// cfg.Plugins.MD, breaking PrimitiveDecode for the user-file primitive.
+func TestPluginConfig_PluginOnlyInUser(t *testing.T) {
+	userCfg := setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, userCfg, `
+[plugins.autoupdate]
+repo = "u/only"
+`)
+	// Project file exists and parses cleanly but does not mention autoupdate.
+	writeFile(t, ProjectPath(projRoot), `
+[ui]
+tree_width = 42
+`)
+	c, _, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	raw := c.PluginConfig("autoupdate")
+	if raw == nil {
+		t.Fatal("user-only plugin lost when project file present")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["repo"] != "u/only" {
+		t.Errorf("repo = %v", got["repo"])
+	}
+}
+
+func TestPluginConfig_PluginOnlyInProject(t *testing.T) {
+	userCfg := setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, userCfg, `
+[ui]
+tree_width = 42
+`)
+	writeFile(t, ProjectPath(projRoot), `
+[plugins.autoupdate]
+repo = "p/only"
+`)
+	c, _, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	raw := c.PluginConfig("autoupdate")
+	if raw == nil {
+		t.Fatal("project-only plugin lost when user file present")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["repo"] != "p/only" {
+		t.Errorf("repo = %v", got["repo"])
+	}
+}
+
+func TestPluginConfig_EnvOverlayWinsOverFiles(t *testing.T) {
+	userCfg := setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, userCfg, `
+[plugins.autoupdate]
+repo = "u/file"
+`)
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "env/wins")
+
+	c, _, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(c.PluginConfig("autoupdate"), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["repo"] != "env/wins" {
+		t.Errorf("env should win over file: repo=%v", got["repo"])
+	}
+}
+
+func TestLoadPluginSubTable(t *testing.T) {
+	_ = setupIsolatedHome(t)
+	projRoot := t.TempDir()
+
+	writeFile(t, ProjectPath(projRoot), `
+[plugins.treepane]
+skip_dirs = [".git", "dist"]
+`)
+	c, _, err := Load(projRoot)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	raw := c.PluginConfig("treepane")
+	if raw == nil {
+		t.Fatal("treepane plugin config was nil")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	dirs, ok := got["skip_dirs"].([]any)
+	if !ok {
+		t.Fatalf("skip_dirs not a slice: %T", got["skip_dirs"])
+	}
+	if len(dirs) != 2 || dirs[0] != ".git" || dirs[1] != "dist" {
+		t.Errorf("skip_dirs = %v", dirs)
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// UserPath returns the canonical per-user config path:
+// <UserConfigDir>/nistru/config.toml. No directories are created. Mirrors
+// the style of plugin.userPluginsRoot / autoupdate.StatePath.
+func UserPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("config: user config dir: %w", err)
+	}
+	return filepath.Join(dir, "nistru", "config.toml"), nil
+}
+
+// ProjectPath returns <root>/.nistru/config.toml. It does not check for
+// existence — callers decide what to do when the file is absent.
+func ProjectPath(root string) string {
+	return filepath.Join(root, ".nistru", "config.toml")
+}

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUserPath(t *testing.T) {
+	p, err := UserPath()
+	if err != nil {
+		// On hosts without a UserConfigDir this is expected. Nothing more to check.
+		return
+	}
+	want, werr := os.UserConfigDir()
+	if werr != nil {
+		t.Fatalf("UserConfigDir: %v", werr)
+	}
+	if !strings.HasPrefix(p, want) {
+		t.Errorf("UserPath %q should live under %q", p, want)
+	}
+	if filepath.Base(p) != "config.toml" {
+		t.Errorf("UserPath base = %q, want config.toml", filepath.Base(p))
+	}
+	if filepath.Base(filepath.Dir(p)) != "nistru" {
+		t.Errorf("UserPath dir = %q, want .../nistru/config.toml", p)
+	}
+}
+
+func TestProjectPath(t *testing.T) {
+	root := t.TempDir()
+	p := ProjectPath(root)
+	want := filepath.Join(root, ".nistru", "config.toml")
+	if p != want {
+		t.Errorf("ProjectPath = %q, want %q", p, want)
+	}
+}

--- a/internal/config/skeleton.go
+++ b/internal/config/skeleton.go
@@ -1,0 +1,46 @@
+package config
+
+// CommentedDefaults returns a TOML skeleton that lists every key in the
+// v1 schema as a commented-out line prefixed with "# ", together with
+// short section headers. Users uncomment the lines they want to change
+// (Kitty-style). Used by the `openUser` palette command to seed a fresh
+// user config file.
+func CommentedDefaults() string {
+	return `# Nistru configuration.
+# Uncomment any line below to override the built-in default.
+# Schema v1. See the Nistru repository for per-key documentation.
+
+# [editor]
+# max_file_size = "1MiB"
+
+# [ui]
+# tree_width        = 30
+# saved_fade_after  = "3s"
+# relative_numbers  = true
+
+# [autosave]
+# save_debounce   = "250ms"
+# change_debounce = "50ms"
+
+# [keymap]
+# save       = "ctrl+s"
+# quit       = "ctrl+q"
+# palette    = "ctrl+p"
+# focus_next = "tab"
+# focus_prev = "shift+tab"
+# undo       = "ctrl+z"
+# redo       = "ctrl+y"
+# cut_line   = "ctrl+x"
+# copy_line  = "ctrl+c"
+# paste      = "ctrl+v"
+
+# [plugins.autoupdate]
+# repo     = "savimcio/nistru"
+# channel  = "release"
+# interval = "1h"
+# disable  = false
+
+# [plugins.treepane]
+# skip_dirs = [".git", "node_modules", "vendor", "dist", "build"]
+`
+}

--- a/internal/config/skeleton_test.go
+++ b/internal/config/skeleton_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestCommentedDefaultsParsesCleanly(t *testing.T) {
+	s := CommentedDefaults()
+	if s == "" {
+		t.Fatal("empty skeleton")
+	}
+	// toml.Decode should accept a file that is entirely comments + blanks.
+	var dst map[string]any
+	if _, err := toml.Decode(s, &dst); err != nil {
+		t.Fatalf("skeleton didn't parse: %v", err)
+	}
+	// Because every non-header line is commented out, decoding yields an
+	// empty map.
+	if len(dst) != 0 {
+		t.Errorf("skeleton should decode to empty map, got %v", dst)
+	}
+}
+
+func TestCommentedDefaultsEveryLineIsCommentOrBlank(t *testing.T) {
+	s := CommentedDefaults()
+	for i, line := range strings.Split(s, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		t.Errorf("line %d is neither blank nor commented: %q", i+1, line)
+	}
+}
+
+func TestCommentedDefaultsContainsKeyMarkers(t *testing.T) {
+	s := CommentedDefaults()
+	for _, want := range []string{
+		"tree_width",
+		"save_debounce",
+		"[keymap]",
+		"[plugins.autoupdate]",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("skeleton missing %q", want)
+		}
+	}
+}

--- a/internal/editor/autosave.go
+++ b/internal/editor/autosave.go
@@ -39,20 +39,23 @@ type openFileRequestMsg struct {
 	path string
 }
 
-// scheduleSave returns a tea.Cmd that fires a saveTickMsg after the debounce
-// window. Later edits bump saveGen so this tick will no-op when it lands.
-func scheduleSave(gen int) tea.Cmd {
-	return tea.Tick(250*time.Millisecond, func(time.Time) tea.Msg {
+// scheduleSave returns a tea.Cmd that fires a saveTickMsg after the provided
+// debounce window. Later edits bump saveGen so this tick will no-op when it
+// lands. The debounce duration is supplied by the caller (see
+// config.Autosave.SaveDebounce) so the helper stays pure.
+func scheduleSave(gen int, debounce time.Duration) tea.Cmd {
+	return tea.Tick(debounce, func(time.Time) tea.Msg {
 		return saveTickMsg{gen: gen}
 	})
 }
 
 // scheduleChange returns a tea.Cmd that fires a changeTickMsg after the
-// debounce window. Later edits bump changeGen so this tick will no-op when
-// it lands. Shorter than scheduleSave because plugin consumers (formatters,
-// linters) want quicker feedback than the autosave cadence.
-func scheduleChange(gen int) tea.Cmd {
-	return tea.Tick(50*time.Millisecond, func(time.Time) tea.Msg {
+// provided debounce window. Later edits bump changeGen so this tick will
+// no-op when it lands. Shorter than scheduleSave in practice because plugin
+// consumers (formatters, linters) want quicker feedback than the autosave
+// cadence; the exact value lives in config.Autosave.ChangeDebounce.
+func scheduleChange(gen int, debounce time.Duration) tea.Cmd {
+	return tea.Tick(debounce, func(time.Time) tea.Msg {
 		return changeTickMsg{gen: gen}
 	})
 }

--- a/internal/editor/autosave_test.go
+++ b/internal/editor/autosave_test.go
@@ -120,7 +120,7 @@ func TestScheduleSave_EmitsSaveTickMsgWithGen(t *testing.T) {
 		t.Skip("relies on 250ms debounce timer; use full go test to run")
 	}
 	t.Parallel()
-	cmd := scheduleSave(42)
+	cmd := scheduleSave(42, 250*time.Millisecond)
 	if cmd == nil {
 		t.Fatalf("scheduleSave returned nil cmd")
 	}
@@ -137,7 +137,7 @@ func TestScheduleSave_EmitsSaveTickMsgWithGen(t *testing.T) {
 func TestScheduleChange_EmitsChangeTickMsgWithGen(t *testing.T) {
 	// 50ms debounce — fast enough to run under -short.
 	t.Parallel()
-	cmd := scheduleChange(7)
+	cmd := scheduleChange(7, 50*time.Millisecond)
 	if cmd == nil {
 		t.Fatalf("scheduleChange returned nil cmd")
 	}
@@ -165,8 +165,8 @@ func TestScheduleSave_StaleVsCurrent(t *testing.T) {
 	// to a single 250ms window instead of two back-to-back windows.
 	staleCh := make(chan tea.Msg, 1)
 	freshCh := make(chan tea.Msg, 1)
-	staleCmd := scheduleSave(10)
-	freshCmd := scheduleSave(11)
+	staleCmd := scheduleSave(10, 250*time.Millisecond)
+	freshCmd := scheduleSave(11, 250*time.Millisecond)
 	go func() { staleCh <- staleCmd() }()
 	go func() { freshCh <- freshCmd() }()
 

--- a/internal/editor/autoupdate_integration_test.go
+++ b/internal/editor/autoupdate_integration_test.go
@@ -113,7 +113,7 @@ func TestAutoupdatePluginEndToEnd(t *testing.T) {
 	)
 	registry.RegisterInProc(au)
 
-	m, err := newModelWithRegistry(root, registry)
+	m, err := newModelWithRegistry(root, registry, nil)
 	if err != nil {
 		t.Fatalf("newModelWithRegistry: %v", err)
 	}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -3,7 +3,18 @@ package editor
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/kujtimiihoxha/vimtea"
+
+	"github.com/savimcio/nistru/internal/config"
 )
+
+// editorOpts bundles the config-driven knobs newEditor consumes. A nil
+// pointer means "use defaults" — which keeps hand-constructed test Models
+// calling newEditor("", "") without a config handy. The fields default to
+// the built-in keymap and enabled relative numbers when zero-valued.
+type editorOpts struct {
+	Keymap          config.Keymap
+	RelativeNumbers bool
+}
 
 // newEditor constructs a fresh vimtea.Editor and registers the micro-style
 // Ctrl bindings that live inside the editor (Ctrl+Z/Y/X/C/V for undo, redo,
@@ -11,24 +22,51 @@ import (
 // level — they are app-wide concerns, not editor concerns — so they are NOT
 // registered here.
 //
+// opts (variadic, at most one) supplies the user's keymap and whether the
+// editor renders relative line numbers. Passing no opts is equivalent to
+// passing a nil pointer: defaults apply. Production callers pass the
+// resolved config's fields; hand-constructed Models in tests omit it.
+//
 // This factory is called from two places:
 //  1. main.go / initial model construction, with empty content.
 //  2. model.go, when a file is opened from the tree (fresh Editor per open).
 //
 // Because the editor is reconstructed on each open, the bindings below are
 // re-registered every time — a fresh Editor has no user bindings.
-func newEditor(content, path string) vimtea.Editor {
-	opts := []vimtea.EditorOption{
+func newEditor(content, path string, opts ...*editorOpts) vimtea.Editor {
+	var o *editorOpts
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	km, relNums := resolveEditorOpts(o)
+
+	vopts := []vimtea.EditorOption{
 		vimtea.WithContent(content),
-		vimtea.WithRelativeNumbers(true),
+		vimtea.WithRelativeNumbers(relNums),
 	}
 	if path != "" {
-		opts = append(opts, vimtea.WithFileName(path))
+		vopts = append(vopts, vimtea.WithFileName(path))
 	}
-	e := vimtea.NewEditor(opts...)
+	e := vimtea.NewEditor(vopts...)
 
-	addCtrlBindings(e)
+	addCtrlBindings(e, km)
 	return e
+}
+
+// resolveEditorOpts returns the effective keymap + relative-numbers setting
+// for a (possibly nil) editorOpts pointer. Split out so both newEditor and
+// direct callers in tests can compute the same defaults without duplicating
+// the condition logic.
+func resolveEditorOpts(o *editorOpts) (config.Keymap, bool) {
+	if o == nil {
+		d := config.Defaults()
+		return d.Keymap, d.UI.RelativeNumbers
+	}
+	km := o.Keymap
+	if km == nil {
+		km = config.DefaultKeymap()
+	}
+	return km, o.RelativeNumbers
 }
 
 // addCtrlBindings registers micro-style Ctrl shortcuts inside the editor.
@@ -54,12 +92,22 @@ func newEditor(content, path string) vimtea.Editor {
 // Buffer does not expose direct DeleteLine/YankLine/Paste primitives, so the
 // tea.Sequence-through-the-key-path remains the only way to reach vimtea's
 // motion engine from a binding handler.
-func addCtrlBindings(e vimtea.Editor) {
+//
+// Keys are resolved via km.Lookup(action) so a user can rebind any of them
+// through the config's [keymap] table. A nil or incomplete Keymap falls back
+// to the built-in defaults (see config.Keymap.Lookup).
+func addCtrlBindings(e vimtea.Editor, km config.Keymap) {
 	modes := []vimtea.EditorMode{vimtea.ModeNormal, vimtea.ModeInsert, vimtea.ModeVisual}
+
+	undoKey := km.Lookup(config.ActionUndo)
+	redoKey := km.Lookup(config.ActionRedo)
+	cutKey := km.Lookup(config.ActionCutLine)
+	copyKey := km.Lookup(config.ActionCopyLine)
+	pasteKey := km.Lookup(config.ActionPaste)
 
 	for _, mode := range modes {
 		e.AddBinding(vimtea.KeyBinding{
-			Key:         "ctrl+z",
+			Key:         undoKey,
 			Mode:        mode,
 			Description: "undo",
 			Handler: func(buf vimtea.Buffer) tea.Cmd {
@@ -68,7 +116,7 @@ func addCtrlBindings(e vimtea.Editor) {
 		})
 
 		e.AddBinding(vimtea.KeyBinding{
-			Key:         "ctrl+y",
+			Key:         redoKey,
 			Mode:        mode,
 			Description: "redo",
 			Handler: func(buf vimtea.Buffer) tea.Cmd {
@@ -77,7 +125,7 @@ func addCtrlBindings(e vimtea.Editor) {
 		})
 
 		e.AddBinding(vimtea.KeyBinding{
-			Key:         "ctrl+x",
+			Key:         cutKey,
 			Mode:        mode,
 			Description: "cut line",
 			Handler: func(buf vimtea.Buffer) tea.Cmd {
@@ -86,7 +134,7 @@ func addCtrlBindings(e vimtea.Editor) {
 		})
 
 		e.AddBinding(vimtea.KeyBinding{
-			Key:         "ctrl+c",
+			Key:         copyKey,
 			Mode:        mode,
 			Description: "copy line",
 			Handler: func(buf vimtea.Buffer) tea.Cmd {
@@ -95,7 +143,7 @@ func addCtrlBindings(e vimtea.Editor) {
 		})
 
 		e.AddBinding(vimtea.KeyBinding{
-			Key:         "ctrl+v",
+			Key:         pasteKey,
 			Mode:        mode,
 			Description: "paste",
 			Handler: func(buf vimtea.Buffer) tea.Cmd {

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -51,7 +51,7 @@ type setModeSentinel struct {
 
 func TestAddCtrlBindings_RegistersFiveKeysAcrossThreeModes(t *testing.T) {
 	rec := &recordingEditor{}
-	addCtrlBindings(rec)
+	addCtrlBindings(rec, nil)
 
 	wantKeys := []string{"ctrl+z", "ctrl+y", "ctrl+x", "ctrl+c", "ctrl+v"}
 	wantModes := []vimtea.EditorMode{vimtea.ModeNormal, vimtea.ModeInsert, vimtea.ModeVisual}

--- a/internal/editor/model.go
+++ b/internal/editor/model.go
@@ -13,28 +13,24 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/kujtimiihoxha/vimtea"
 
+	"github.com/savimcio/nistru/internal/config"
 	"github.com/savimcio/nistru/internal/plugins/autoupdate"
+	"github.com/savimcio/nistru/internal/plugins/settingscmd"
 	"github.com/savimcio/nistru/internal/plugins/treepane"
 	"github.com/savimcio/nistru/plugin"
 )
 
-// App-level key constants. Inlining these rather than splitting into keys.go
-// because there are only a handful.
-const (
-	keyTab      = "tab"
-	keyShiftTab = "shift+tab"
-	keyCtrlS    = "ctrl+s"
-	keyCtrlQ    = "ctrl+q"
-	keyCtrlC    = "ctrl+c"
-	keyCtrlP    = "ctrl+p"
-)
+// keyCtrlC is the tree-pane's universal quit intercept. It stays hardcoded
+// regardless of the user's keymap because Ctrl+C is the terminal's universal
+// interrupt contract — rebinding it would break muscle memory. Every other
+// app-level binding flows through m.cfg.Keymap.
+const keyCtrlC = "ctrl+c"
 
-// Layout constants.
+// Layout constants. Only statusBarLines is truly fixed; the other knobs
+// (treeWidth, maxFileSize, savedFadeAfter) now live on the Model via
+// m.cfg (UI.TreeWidth, Editor.MaxFileSize, UI.SavedFadeAfter).
 const (
-	treeWidth      = 30
 	statusBarLines = 1
-	maxFileSize    = 1 << 20 // 1 MiB — refuse to open files larger than this
-	savedFadeAfter = 3 * time.Second
 )
 
 type focus int
@@ -67,6 +63,7 @@ type statusSegment struct {
 // autosave/change-debounce bookkeeping.
 type Model struct {
 	root string
+	cfg  *config.Config
 
 	host     *plugin.Host
 	registry *plugin.Registry
@@ -107,8 +104,18 @@ type Model struct {
 }
 
 // NewModel constructs the initial app model rooted at root. The editor starts
-// empty; opening a file through the tree replaces it.
-func NewModel(root string) (*Model, error) {
+// empty; opening a file through the tree replaces it. A nil cfg is equivalent
+// to config.Defaults() — tests that don't care about configuration pass nil
+// and get the built-in defaults without having to thread a loader through.
+//
+// The settingscmd plugin needs a live handle to the Model's config so its
+// showResolved / reload commands reflect the post-reload state. We solve the
+// circular dependency with a pointer-to-pointer: mref is nil until
+// newModelWithRegistry finishes building m, then gets its address. settingscmd
+// only calls getCfg lazily (on palette command invocation), never during
+// registration, so "nil mref means cfg is not ready yet" never fires in
+// practice — but the fallback keeps the closure total.
+func NewModel(root string, cfg *config.Config) (*Model, error) {
 	registry := plugin.NewRegistry()
 
 	tp, err := treepane.New(root)
@@ -119,7 +126,21 @@ func NewModel(root string) (*Model, error) {
 
 	registry.RegisterInProc(autoupdate.New())
 
-	return newModelWithRegistry(root, registry)
+	var mref *Model
+	getCfg := func() *config.Config {
+		if mref == nil {
+			return cfg
+		}
+		return mref.cfg
+	}
+	registry.RegisterInProc(settingscmd.New(root, getCfg))
+
+	m, err := newModelWithRegistry(root, registry, cfg)
+	if err != nil {
+		return nil, err
+	}
+	mref = m
+	return m, nil
 }
 
 // newModelWithRegistry is the shared constructor used by NewModel and by
@@ -134,8 +155,14 @@ func NewModel(root string) (*Model, error) {
 // through PostNotif whose host-side bookkeeping runs before the inbound
 // channel send, so the subsequent host.Commands() snapshot already includes
 // anything a plugin registered during Initialize.
-func newModelWithRegistry(root string, registry *plugin.Registry) (*Model, error) {
+func newModelWithRegistry(root string, registry *plugin.Registry, cfg *config.Config) (*Model, error) {
+	if cfg == nil {
+		cfg = config.Defaults()
+	}
 	host := plugin.NewHost(registry)
+	// Install the per-plugin config lookup BEFORE Start/Emit so Initialize
+	// carries each plugin's sub-tree in the same dispatch.
+	host.SetPluginConfig(cfg.PluginConfig)
 	if err := host.Start(root); err != nil {
 		return nil, fmt.Errorf("start plugin host: %w", err)
 	}
@@ -144,11 +171,12 @@ func newModelWithRegistry(root string, registry *plugin.Registry) (*Model, error
 
 	m := &Model{
 		root:     root,
+		cfg:      cfg,
 		host:     host,
 		registry: registry,
 		leftPane: host.Pane("left"),
 		commands: host.Commands(),
-		editor:   newEditor("", ""),
+		editor:   newEditor("", "", &editorOpts{Keymap: cfg.Keymap, RelativeNumbers: cfg.UI.RelativeNumbers}),
 		focus:    focusTree,
 	}
 	return m, nil
@@ -168,9 +196,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		contentH = max(contentH, 1)
 		editorW := m.editorWidth()
 		if m.leftPane != nil {
-			if treeWidth != m.lastPaneW || contentH != m.lastPaneH {
-				m.leftPane.OnResize(treeWidth, contentH)
-				m.lastPaneW = treeWidth
+			tw := m.treeWidth()
+			if tw != m.lastPaneW || contentH != m.lastPaneH {
+				m.leftPane.OnResize(tw, contentH)
+				m.lastPaneW = tw
 				m.lastPaneH = contentH
 			}
 		}
@@ -248,13 +277,82 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // editorWidth returns the editor's width in cells, allowing for a missing
-// left pane (in which case the editor fills the screen).
+// left pane (in which case the editor fills the screen). The tree pane's
+// width comes from the user's config via m.cfg.UI.TreeWidth; falling back to
+// the default keeps partially-initialised test Models (m.cfg == nil) safe.
 func (m *Model) editorWidth() int {
 	w := m.width
 	if m.leftPane != nil {
-		w = m.width - treeWidth
+		w = m.width - m.treeWidth()
 	}
 	return max(w, 1)
+}
+
+// treeWidth returns the configured left-pane width, defaulting to the
+// built-in constant when m.cfg is nil (i.e. in hand-constructed test
+// Models).
+func (m *Model) treeWidth() int {
+	if m.cfg == nil {
+		return config.Defaults().UI.TreeWidth
+	}
+	return m.cfg.UI.TreeWidth
+}
+
+// keymap returns the active Keymap, falling back to the built-in defaults
+// when m.cfg is nil. Hand-built test Models routinely skip wiring m.cfg, so
+// the defensive return keeps every keypath safe without burdening each call
+// site with a nil check.
+func (m *Model) keymap() config.Keymap {
+	if m.cfg == nil {
+		return config.DefaultKeymap()
+	}
+	return m.cfg.Keymap
+}
+
+// savedFadeAfter returns the UI.SavedFadeAfter duration, falling back to
+// the built-in default when m.cfg is nil.
+func (m *Model) savedFadeAfter() time.Duration {
+	if m.cfg == nil {
+		return config.Defaults().UI.SavedFadeAfter
+	}
+	return m.cfg.UI.SavedFadeAfter
+}
+
+// maxFileSize returns the open-file size ceiling, falling back to the
+// built-in default when m.cfg is nil.
+func (m *Model) maxFileSize() uint64 {
+	if m.cfg == nil {
+		return uint64(config.Defaults().Editor.MaxFileSize)
+	}
+	return uint64(m.cfg.Editor.MaxFileSize)
+}
+
+// editorOptsFromCfg returns the editorOpts derived from m.cfg, suitable for
+// passing to newEditor. Returns nil when m.cfg is nil so newEditor falls
+// back to its own defaults.
+func (m *Model) editorOptsFromCfg() *editorOpts {
+	if m.cfg == nil {
+		return nil
+	}
+	return &editorOpts{Keymap: m.cfg.Keymap, RelativeNumbers: m.cfg.UI.RelativeNumbers}
+}
+
+// saveDebounce returns the autosave debounce window, falling back to the
+// built-in default when m.cfg is nil.
+func (m *Model) saveDebounce() time.Duration {
+	if m.cfg == nil {
+		return config.Defaults().Autosave.SaveDebounce
+	}
+	return m.cfg.Autosave.SaveDebounce
+}
+
+// changeDebounce returns the DidChange debounce window, falling back to the
+// built-in default when m.cfg is nil.
+func (m *Model) changeDebounce() time.Duration {
+	if m.cfg == nil {
+		return config.Defaults().Autosave.ChangeDebounce
+	}
+	return m.cfg.Autosave.ChangeDebounce
 }
 
 // handlePluginNotif translates an inbound JSON-RPC notification from an
@@ -317,7 +415,7 @@ func (m *Model) handlePluginReq(msg plugin.PluginReqMsg) (tea.Model, tea.Cmd) {
 			})
 			return m, m.host.Recv()
 		}
-		m.editor = newEditor(p.Text, p.Path)
+		m.editor = newEditor(p.Text, p.Path, m.editorOptsFromCfg())
 		contentH := m.height - statusBarLines
 		contentH = max(contentH, 1)
 		if newEd, _ := m.editor.SetSize(m.editorWidth(), contentH); newEd != nil {
@@ -408,11 +506,13 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.palette.open {
 		return m.handlePaletteKey(msg)
 	}
-	switch msg.String() {
-	case keyCtrlP:
+	key := msg.String()
+	km := m.keymap()
+	switch key {
+	case km.Lookup(config.ActionPalette):
 		m.palette.Open(m.commands)
 		return m, nil
-	case keyTab, keyShiftTab:
+	case km.Lookup(config.ActionFocusNext), km.Lookup(config.ActionFocusPrev):
 		prev := m.focus
 		if m.focus == focusTree {
 			m.focus = focusEditor
@@ -424,7 +524,7 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case keyCtrlS:
+	case km.Lookup(config.ActionSave):
 		// App-wide manual save, works regardless of focus and mode.
 		if err := m.flushNow(); err != nil {
 			m.statusErr = err.Error()
@@ -432,7 +532,7 @@ func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, m.editor.SetStatusMessage("saved")
 
-	case keyCtrlQ:
+	case km.Lookup(config.ActionQuit):
 		return m.guardedQuit()
 	}
 
@@ -529,8 +629,8 @@ func (m *Model) forwardToFocused(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.dirty = true
 			m.saveGen++
 			m.changeGen++
-			tick := scheduleSave(m.saveGen)
-			changeTick := scheduleChange(m.changeGen)
+			tick := scheduleSave(m.saveGen, m.saveDebounce())
+			changeTick := scheduleChange(m.changeGen, m.changeDebounce())
 			if cmd == nil {
 				return m, tea.Batch(tick, changeTick)
 			}
@@ -583,6 +683,10 @@ func (m *Model) applyEffects(effs []plugin.Effect) tea.Cmd {
 			}
 		case plugin.Invalidate:
 			// No-op: Bubble Tea repaints every tick.
+		case plugin.ReloadConfigRequest:
+			// The reload lives in a method so the surrounding switch stays a
+			// routing table — the flow is too big to inline.
+			cmds = append(cmds, m.reloadConfig())
 		}
 	}
 	if len(cmds) == 0 {
@@ -592,6 +696,107 @@ func (m *Model) applyEffects(effs []plugin.Effect) tea.Cmd {
 		return cmds[0]
 	}
 	return tea.Batch(cmds...)
+}
+
+// reloadConfig reparses the layered TOML config from disk, swaps the
+// Model's cfg in place so every closure holding m.cfg sees the update,
+// pushes the new plugin lookup into the host, and re-emits Initialize to
+// already-activated plugins so they can pick up fresh per-plugin config.
+// Warnings are printed to stderr in the same style as cmd/nistru/main.go
+// — we duplicate the loop here rather than extract a helper, because the
+// one-line format is trivial and both call sites stay independent.
+//
+// A vimtea.Editor baked in its opts at construction time (relative numbers
+// and the Ctrl-binding keymap), so for those specific knobs we detect a
+// change and rebuild the editor instance in place. Content and file path
+// are preserved; cursor position and vim mode are reset — acceptable v1
+// tradeoff, called out in the return contract.
+func (m *Model) reloadConfig() tea.Cmd {
+	newCfg, warnings, err := config.Load(m.root)
+	if err != nil {
+		return m.editor.SetStatusMessage("reload failed: " + err.Error())
+	}
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "nistru: config: %s: %s\n", w.Source, w.Message)
+	}
+	// Snapshot the editor-relevant knobs BEFORE the in-place mutation so the
+	// post-swap comparison has something to diff against. Copying the Keymap
+	// (a map) is necessary because *m.cfg = *newCfg shares the underlying
+	// map header — without a snapshot, oldKeymap would already reflect the
+	// new bindings by the time we compared.
+	var oldKnobs editorKnobs
+	if m.cfg != nil {
+		oldKnobs = snapshotEditorKnobs(m.cfg)
+	}
+
+	// In-place mutation preserves m.cfg's address so any closure captured
+	// during construction (e.g. settingscmd's getCfg) automatically sees
+	// the fresh values without needing a refresh hook.
+	if m.cfg != nil && newCfg != nil {
+		*m.cfg = *newCfg
+	} else {
+		m.cfg = newCfg
+	}
+
+	var initCmd tea.Cmd
+	if m.cfg != nil && editorKnobsChanged(oldKnobs, snapshotEditorKnobs(m.cfg)) {
+		buf := m.editor.GetBuffer().Text()
+		m.editor = newEditor(buf, m.openPath, m.editorOptsFromCfg())
+		contentH := m.height - statusBarLines
+		contentH = max(contentH, 1)
+		if newEd, _ := m.editor.SetSize(m.editorWidth(), contentH); newEd != nil {
+			if e, ok := newEd.(vimtea.Editor); ok {
+				m.editor = e
+			}
+		}
+		initCmd = m.editor.Init()
+	}
+
+	m.host.SetPluginConfig(m.cfg.PluginConfig)
+	m.host.ReEmitInitialize()
+
+	msg := m.editor.SetStatusMessage("settings reloaded")
+	if initCmd != nil {
+		return tea.Batch(initCmd, msg)
+	}
+	return msg
+}
+
+// editorKnobs is the subset of config.Config that the vimtea editor bakes in
+// at construction time — changing any of these means we must rebuild the
+// editor instance for the change to take effect.
+type editorKnobs struct {
+	relativeNumbers bool
+	undoKey         string
+	redoKey         string
+	cutKey          string
+	copyKey         string
+	pasteKey        string
+}
+
+// snapshotEditorKnobs copies the editor-relevant fields out of cfg into a
+// plain struct so they survive an in-place overwrite of *m.cfg. cfg must be
+// non-nil.
+func snapshotEditorKnobs(cfg *config.Config) editorKnobs {
+	km := cfg.Keymap
+	if km == nil {
+		km = config.DefaultKeymap()
+	}
+	return editorKnobs{
+		relativeNumbers: cfg.UI.RelativeNumbers,
+		undoKey:         km.Lookup(config.ActionUndo),
+		redoKey:         km.Lookup(config.ActionRedo),
+		cutKey:          km.Lookup(config.ActionCutLine),
+		copyKey:         km.Lookup(config.ActionCopyLine),
+		pasteKey:        km.Lookup(config.ActionPaste),
+	}
+}
+
+// editorKnobsChanged reports whether any editor-relevant knob differs between
+// two snapshots. A plain struct equality check would suffice today, but the
+// named helper documents intent at the call site.
+func editorKnobsChanged(a, b editorKnobs) bool {
+	return a != b
 }
 
 // openFile handles opening path: read the file, guard against binary/oversize
@@ -607,8 +812,9 @@ func (m *Model) openFile(path string) (tea.Model, tea.Cmd) {
 	if info.IsDir() {
 		return m, nil
 	}
-	if info.Size() > maxFileSize {
-		return m, m.editor.SetStatusMessage(fmt.Sprintf("refusing: file > %d bytes", maxFileSize))
+	maxSz := m.maxFileSize()
+	if uint64(info.Size()) > maxSz {
+		return m, m.editor.SetStatusMessage(fmt.Sprintf("refusing: file > %d bytes", maxSz))
 	}
 
 	b, err := os.ReadFile(path)
@@ -635,7 +841,7 @@ func (m *Model) openFile(path string) (tea.Model, tea.Cmd) {
 	prevPath := m.openPath
 
 	content := string(b)
-	m.editor = newEditor(content, path)
+	m.editor = newEditor(content, path, m.editorOptsFromCfg())
 
 	// Push the current size into the new editor instance.
 	contentH := m.height - statusBarLines
@@ -731,21 +937,22 @@ func (m *Model) View() string {
 
 	var content string
 	if m.leftPane != nil {
+		tw := m.treeWidth()
 		// Notify pane of current dims if they changed since last Render.
-		if treeWidth != m.lastPaneW || contentH != m.lastPaneH {
-			m.leftPane.OnResize(treeWidth, contentH)
-			m.lastPaneW = treeWidth
+		if tw != m.lastPaneW || contentH != m.lastPaneH {
+			m.leftPane.OnResize(tw, contentH)
+			m.lastPaneW = tw
 			m.lastPaneH = contentH
 		}
 		treeStyle := lipgloss.NewStyle().
-			Width(treeWidth).
+			Width(tw).
 			Height(contentH).
 			BorderStyle(lipgloss.NormalBorder()).
 			BorderRight(true)
 		if m.focus == focusTree {
 			treeStyle = treeStyle.BorderForeground(lipgloss.Color("205"))
 		}
-		treePane := treeStyle.Render(m.leftPane.Render(treeWidth, contentH))
+		treePane := treeStyle.Render(m.leftPane.Render(tw, contentH))
 		editorPane := editorStyle.Render(m.editor.View())
 		content = lipgloss.JoinHorizontal(lipgloss.Top, treePane, editorPane)
 	} else {
@@ -778,7 +985,7 @@ func (m *Model) renderStatusBar() string {
 		saveIndicator = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render("! " + m.statusErr)
 	case m.dirty:
 		saveIndicator = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render("● unsaved")
-	case !m.lastSavedAt.IsZero() && time.Since(m.lastSavedAt) < savedFadeAfter:
+	case !m.lastSavedAt.IsZero() && time.Since(m.lastSavedAt) < m.savedFadeAfter():
 		saveIndicator = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Render("✓ saved")
 	default:
 		saveIndicator = ""

--- a/internal/editor/model_component_test.go
+++ b/internal/editor/model_component_test.go
@@ -5,11 +5,15 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/savimcio/nistru/internal/config"
+	"github.com/savimcio/nistru/internal/plugins/settingscmd"
+	"github.com/savimcio/nistru/internal/plugins/treepane"
 	"github.com/savimcio/nistru/plugin"
 )
 
@@ -36,7 +40,7 @@ func newTestModel(t *testing.T, root string) *Model {
 	t.Setenv("NISTRU_AUTOUPDATE_REPO", "")
 	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "")
 	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "")
-	m, err := NewModel(root)
+	m, err := NewModel(root, nil)
 	if err != nil {
 		t.Fatalf("NewModel(%q): %v", root, err)
 	}
@@ -680,3 +684,422 @@ func TestModel_PluginMessagePlumbing(t *testing.T) {
 type errSentinel struct{}
 
 func (errSentinel) Error() string { return "crashed: simulated" }
+
+// -----------------------------------------------------------------------------
+// T4 config-threading regression tests. These lock in the behaviour that
+// Model's config knobs (keymap, tree width, per-plugin config) flow through
+// the constructor path into the runtime, rather than being hardcoded.
+
+// TestModel_CustomKeymap_SavesOnConfiguredKey asserts that rebinding
+// ActionSave in the keymap reroutes the save handler accordingly. We bind
+// Save to F5 (a chord that tea.KeyMsg natively round-trips through
+// .String()), feed a KeyF5 KeyMsg, and verify flushNow ran — via the
+// nowFunc-stubbed lastSavedAt and the file landing on disk.
+//
+// F5 is chosen because more exotic chords like ctrl+shift+s require escape
+// sequences tea.KeyMsg doesn't let us synthesize directly, and the point
+// of this test is the routing, not the chord encoding.
+func TestModel_CustomKeymap_SavesOnConfiguredKey(t *testing.T) {
+	stubTime := time.Date(2099, 1, 2, 3, 4, 5, 0, time.UTC)
+	prev := nowFunc
+	nowFunc = func() time.Time { return stubTime }
+	t.Cleanup(func() { nowFunc = prev })
+
+	dir := t.TempDir()
+	path := writeFile(t, dir, "a.txt", "seed\n")
+
+	// NewModel still registers treepane + autoupdate, but we only care about
+	// the top-level Model config plumbing here. Disable autoupdate's network.
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "1")
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "")
+	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "")
+
+	cfg := config.Defaults()
+	cfg.Keymap[config.ActionSave] = "f5"
+	m, err := NewModel(dir, cfg)
+	if err != nil {
+		t.Fatalf("NewModel: %v", err)
+	}
+	t.Cleanup(func() { _ = m.host.Shutdown(100 * time.Millisecond) })
+
+	// Open the file and dirty its buffer so flushNow has something to write.
+	newM, _ := m.Update(openFileRequestMsg{path: path})
+	m = newM.(*Model)
+	m.editor.GetBuffer().InsertAt(0, 0, "X")
+	m.dirty = true
+
+	beforeSaved := m.lastSavedAt
+
+	newM, cmd := m.Update(tea.KeyMsg{Type: tea.KeyF5})
+	m = newM.(*Model)
+
+	// If the config-driven binding worked, flushNow ran and lastSavedAt is
+	// the stubbed time. If the binding were still hardcoded to ctrl+s, the
+	// F5 keypress would have fallen through to forwardToFocused — leaving
+	// lastSavedAt unchanged.
+	if m.lastSavedAt.Equal(beforeSaved) {
+		t.Errorf("lastSavedAt did not change; F5 did not trigger configured Save binding")
+	}
+	if !m.lastSavedAt.Equal(stubTime) {
+		t.Errorf("lastSavedAt: got %v, want %v (stubbed)", m.lastSavedAt, stubTime)
+	}
+	if m.dirty {
+		t.Errorf("dirty should be false after save")
+	}
+	if cmd == nil {
+		t.Errorf("handleKey Save path should emit the 'saved' status cmd")
+	}
+	// Assert the file on disk matches the buffer.
+	gotOnDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if string(gotOnDisk) != m.editor.GetBuffer().Text() {
+		t.Errorf("disk mismatch: got %q, want %q", gotOnDisk, m.editor.GetBuffer().Text())
+	}
+}
+
+// TestModel_CustomTreeWidth_AppliesToLayout asserts that m.cfg.UI.TreeWidth
+// flows into OnResize bookkeeping on a WindowSizeMsg. With a custom width
+// of 42, m.lastPaneW should land at 42 after the first tick.
+func TestModel_CustomTreeWidth_AppliesToLayout(t *testing.T) {
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "1")
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "")
+	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "")
+
+	cfg := config.Defaults()
+	cfg.UI.TreeWidth = 42
+
+	dir := t.TempDir()
+	m, err := NewModel(dir, cfg)
+	if err != nil {
+		t.Fatalf("NewModel: %v", err)
+	}
+	t.Cleanup(func() { _ = m.host.Shutdown(100 * time.Millisecond) })
+
+	newM, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	got := newM.(*Model)
+
+	if got.lastPaneW != 42 {
+		t.Errorf("lastPaneW after WindowSize: got %d, want 42 (cfg.UI.TreeWidth)", got.lastPaneW)
+	}
+	if got.treeWidth() != 42 {
+		t.Errorf("treeWidth helper: got %d, want 42", got.treeWidth())
+	}
+}
+
+// TestModel_PluginConfig_FlowsToHost wires a stub in-proc ConfigReceiver
+// into a fresh Registry and asserts that the sub-tree returned by
+// cfg.PluginConfig(name) arrives at the plugin's OnConfig on construction.
+func TestModel_PluginConfig_FlowsToHost(t *testing.T) {
+	root := t.TempDir()
+
+	// Build a Config whose PluginConfig method returns our desired raw bytes
+	// for the stub's name. We bypass the file/env pipeline and inject the
+	// bytes via EnvOverlay: PluginConfig merges file + env and serialises the
+	// result, so env-only populates raw-bytes to a JSON object.
+	cfg := config.Defaults()
+	cfg.Plugins.EnvOverlay = map[string]map[string]any{
+		"stubcfg": {"x": float64(7)},
+	}
+
+	// Build the registry with treepane (for leftPane wiring) + our stub.
+	registry := plugin.NewRegistry()
+	tp, err := treepane.New(root)
+	if err != nil {
+		t.Fatalf("treepane.New: %v", err)
+	}
+	registry.RegisterInProc(tp)
+
+	stub := &stubConfigReceiver{name: "stubcfg"}
+	registry.RegisterInProc(stub)
+
+	m, err := newModelWithRegistry(root, registry, cfg)
+	if err != nil {
+		t.Fatalf("newModelWithRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = m.host.Shutdown(100 * time.Millisecond) })
+
+	got := stub.last()
+	if got == nil {
+		t.Fatalf("stub plugin never received OnConfig")
+	}
+	// PluginConfig marshals the merged map, so we expect {"x":7} (JSON
+	// number encoding for float64 7).
+	var parsed map[string]any
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("received config not valid JSON: %v (raw=%s)", err, got)
+	}
+	if x, ok := parsed["x"].(float64); !ok || x != 7 {
+		t.Errorf("received config: got %v, want {x:7}", parsed)
+	}
+}
+
+// stubConfigReceiver is a minimal in-proc plugin implementing both the
+// Plugin and ConfigReceiver interfaces; used to observe OnConfig dispatch
+// end-to-end from Host.Emit(Initialize{...}) in newModelWithRegistry.
+type stubConfigReceiver struct {
+	name string
+	mu   sync.Mutex
+	got  json.RawMessage
+}
+
+func (s *stubConfigReceiver) Name() string             { return s.name }
+func (s *stubConfigReceiver) Activation() []string     { return []string{"onStart"} }
+func (s *stubConfigReceiver) OnEvent(any) []plugin.Effect { return nil }
+func (s *stubConfigReceiver) Shutdown() error          { return nil }
+
+func (s *stubConfigReceiver) OnConfig(raw json.RawMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make(json.RawMessage, len(raw))
+	copy(cp, raw)
+	s.got = cp
+	return nil
+}
+
+func (s *stubConfigReceiver) last() json.RawMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.got
+}
+
+// TestModel_ReloadPalette_UpdatesPluginConfig exercises the end-to-end
+// reload flow: settingscmd.reload fires plugin.ReloadConfigRequest, which
+// the Model intercepts and translates into config.Load + SetPluginConfig +
+// ReEmitInitialize. A stub ConfigReceiver observes OnConfig before and
+// after, verifying the swap lands at the plugin level.
+//
+// XDG_CONFIG_HOME redirects UserPath() to tempDir so the real user config
+// tree is never touched. The user config is the only file we mutate —
+// project config stays untouched.
+func TestModel_ReloadPalette_UpdatesPluginConfig(t *testing.T) {
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "1")
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "")
+	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "")
+
+	userDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", userDir)
+	t.Setenv("HOME", userDir)
+
+	userCfgPath, err := config.UserPath()
+	if err != nil {
+		t.Fatalf("UserPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(userCfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	write := func(contents string) {
+		if err := os.WriteFile(userCfgPath, []byte(contents), 0o644); err != nil {
+			t.Fatalf("write user cfg: %v", err)
+		}
+	}
+	write("[plugins.stub]\nk = 1\n")
+
+	// Build a minimal registry manually: treepane for leftPane sugar, the
+	// stub to observe OnConfig, and settingscmd so the reload command is
+	// actually registered in host.Commands().
+	registry := plugin.NewRegistry()
+	tp, err := treepane.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("treepane.New: %v", err)
+	}
+	registry.RegisterInProc(tp)
+
+	stub := &stubConfigReceiver{name: "stub"}
+	registry.RegisterInProc(stub)
+
+	// NOTE: settingscmd is *not* registered through newModelWithRegistry.
+	// We build our own plugin instance whose getCfg closure returns the
+	// Model's cfg lazily, mirroring what NewModel does in production.
+	root := t.TempDir()
+	var mref *Model
+	getCfg := func() *config.Config {
+		if mref == nil {
+			return nil
+		}
+		return mref.cfg
+	}
+	registry.RegisterInProc(settingscmd.New(root, getCfg))
+
+	// Load through the real pipeline so Plugins.Raw/MD are populated the
+	// same way cmd/nistru does.
+	cfg, _, err := config.Load(root)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	m, err := newModelWithRegistry(root, registry, cfg)
+	if err != nil {
+		t.Fatalf("newModelWithRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = m.host.Shutdown(100 * time.Millisecond) })
+	mref = m
+
+	gotBefore := stub.last()
+	if gotBefore == nil {
+		t.Fatalf("stub never received OnConfig on Initialize")
+	}
+	var before map[string]any
+	if err := json.Unmarshal(gotBefore, &before); err != nil {
+		t.Fatalf("unmarshal before: %v", err)
+	}
+	if got, _ := before["k"].(int64); got == 1 {
+		// BurntSushi TOML decodes TOML integers as int64 through
+		// json.RawMessage+map[string]any — but that route goes through
+		// json.Unmarshal and yields float64. Either way we just assert
+		// the pre-state matches k=1 via the numeric-equality helper.
+	}
+	if !numericEq(before["k"], 1) {
+		t.Fatalf("pre-reload stub config = %v, want k=1", before)
+	}
+
+	// Mutate the user config on disk.
+	write("[plugins.stub]\nk = 2\n")
+
+	// Dispatch the reload command through the host exactly like the palette
+	// does. ExecuteCommand returns a Sync result because settingscmd is an
+	// in-proc plugin; apply the effects through m.applyEffects to mirror
+	// handlePaletteKey.
+	result := m.host.ExecuteCommand("nistru.settings.reload", nil)
+	if result.Sync == nil {
+		t.Fatalf("reload command returned no Sync result: %+v", result)
+	}
+	if result.Sync.Err != nil {
+		t.Fatalf("reload command error: %v", result.Sync.Err)
+	}
+	// applyEffects drives reloadConfig for us (it handles the
+	// ReloadConfigRequest case). We discard the returned cmd — it carries
+	// the "settings reloaded" status-bar message, which is not under test.
+	_ = m.applyEffects(result.Sync.Effects)
+
+	gotAfter := stub.last()
+	if gotAfter == nil {
+		t.Fatalf("stub received no OnConfig after reload")
+	}
+	var after map[string]any
+	if err := json.Unmarshal(gotAfter, &after); err != nil {
+		t.Fatalf("unmarshal after: %v", err)
+	}
+	if !numericEq(after["k"], 2) {
+		t.Fatalf("post-reload stub config = %v, want k=2", after)
+	}
+}
+
+// TestModel_ReloadPalette_RelativeNumbersTakesEffect verifies that changing
+// [ui].relative_numbers on disk and firing the reload command actually
+// rebuilds the underlying vimtea.Editor so the new setting is in effect
+// immediately — without waiting for the user to open another file. vimtea
+// doesn't expose the flag on its Editor interface, so the assertion is
+// indirect: we take a before/after snapshot of m.editor's pointer identity
+// and confirm it changed, plus verify m.cfg.UI.RelativeNumbers took the new
+// value. Together, those two checks cover the observable contract — "the
+// editor instance that renders is the one that booted with the new setting".
+func TestModel_ReloadPalette_RelativeNumbersTakesEffect(t *testing.T) {
+	t.Setenv("NISTRU_AUTOUPDATE_DISABLE", "1")
+	t.Setenv("NISTRU_AUTOUPDATE_REPO", "")
+	t.Setenv("NISTRU_AUTOUPDATE_CHANNEL", "")
+	t.Setenv("NISTRU_AUTOUPDATE_INTERVAL", "")
+
+	userDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", userDir)
+	t.Setenv("HOME", userDir)
+
+	userCfgPath, err := config.UserPath()
+	if err != nil {
+		t.Fatalf("UserPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(userCfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	write := func(contents string) {
+		if err := os.WriteFile(userCfgPath, []byte(contents), 0o644); err != nil {
+			t.Fatalf("write user cfg: %v", err)
+		}
+	}
+	// Start with relative_numbers = true (the default) declared explicitly so
+	// the before-state is unambiguous.
+	write("[ui]\nrelative_numbers = true\n")
+
+	registry := plugin.NewRegistry()
+	tp, err := treepane.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("treepane.New: %v", err)
+	}
+	registry.RegisterInProc(tp)
+
+	root := t.TempDir()
+	var mref *Model
+	getCfg := func() *config.Config {
+		if mref == nil {
+			return nil
+		}
+		return mref.cfg
+	}
+	registry.RegisterInProc(settingscmd.New(root, getCfg))
+
+	cfg, _, err := config.Load(root)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if !cfg.UI.RelativeNumbers {
+		t.Fatalf("pre-reload cfg.UI.RelativeNumbers = false, want true")
+	}
+	m, err := newModelWithRegistry(root, registry, cfg)
+	if err != nil {
+		t.Fatalf("newModelWithRegistry: %v", err)
+	}
+	t.Cleanup(func() { _ = m.host.Shutdown(100 * time.Millisecond) })
+	mref = m
+
+	edBefore := m.editor
+
+	// Flip the setting on disk.
+	write("[ui]\nrelative_numbers = false\n")
+
+	result := m.host.ExecuteCommand("nistru.settings.reload", nil)
+	if result.Sync == nil || result.Sync.Err != nil {
+		t.Fatalf("reload command: sync=%+v err=%v", result.Sync, result.Sync != nil && result.Sync.Err != nil)
+	}
+	_ = m.applyEffects(result.Sync.Effects)
+
+	if m.cfg.UI.RelativeNumbers {
+		t.Fatalf("post-reload cfg.UI.RelativeNumbers = true, want false")
+	}
+	if m.editor == edBefore {
+		t.Fatalf("m.editor pointer unchanged after relative_numbers reload; editor still has stale flag")
+	}
+
+	// Inverse case: a reload that changes nothing relevant should NOT
+	// reconstruct the editor — otherwise a routine reload would blow away
+	// cursor position unnecessarily.
+	edAfterFirst := m.editor
+	// No-op change: still relative_numbers=false, just with a comment added.
+	write("[ui]\nrelative_numbers = false\n# no-op change\n")
+	result = m.host.ExecuteCommand("nistru.settings.reload", nil)
+	if result.Sync == nil || result.Sync.Err != nil {
+		t.Fatalf("second reload: sync=%+v", result.Sync)
+	}
+	_ = m.applyEffects(result.Sync.Effects)
+	if m.editor != edAfterFirst {
+		t.Fatalf("m.editor rebuilt on no-op reload; editor should only rebuild when a baked-in knob changed")
+	}
+}
+
+// numericEq reports whether v equals want, accepting any of the numeric
+// types json.Unmarshal (float64) or BurntSushi's primitive decode (int64)
+// might produce for a TOML integer. Keeps the reload test agnostic to the
+// decode path.
+func numericEq(v any, want int) bool {
+	switch x := v.(type) {
+	case float64:
+		return x == float64(want)
+	case int64:
+		return x == int64(want)
+	case int:
+		return x == want
+	}
+	return false
+}

--- a/internal/editor/model_e2e_test.go
+++ b/internal/editor/model_e2e_test.go
@@ -46,8 +46,9 @@ import (
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/kujtimiihoxha/vimtea"
 
-	"github.com/savimcio/nistru/plugin"
+	"github.com/savimcio/nistru/internal/config"
 	"github.com/savimcio/nistru/internal/plugins/treepane"
+	"github.com/savimcio/nistru/plugin"
 )
 
 // The `-update` flag is already registered by a transitive dep (one of the
@@ -180,7 +181,7 @@ func newRenderedModel(t *testing.T, root string, w, h int, setup func(*Model)) s
 	// green "v…" segment into the status bar — the resulting non-determinism
 	// drifts every goldens in this file.
 	disableAutoupdate(t)
-	m, err := NewModel(root)
+	m, err := NewModel(root, nil)
 	if err != nil {
 		t.Fatalf("NewModel(%q): %v", root, err)
 	}
@@ -393,7 +394,7 @@ func TestE2E_EditAutosaveToDisk(t *testing.T) {
 	disableAutoupdate(t)
 	dir := t.TempDir()
 	path := writeFile(t, dir, "note.txt", "seed\n")
-	m, err := NewModel(dir)
+	m, err := NewModel(dir, nil)
 	if err != nil {
 		t.Fatalf("NewModel: %v", err)
 	}
@@ -455,7 +456,7 @@ func TestE2E_PaletteRegisteredCommandExecutes(t *testing.T) {
 	// We construct the Host ourselves so we can inject the test plugin.
 	disableAutoupdate(t)
 	root := emptyRoot(t)
-	m, err := NewModel(root)
+	m, err := NewModel(root, nil)
 	if err != nil {
 		t.Fatalf("NewModel: %v", err)
 	}
@@ -492,7 +493,7 @@ func TestE2E_CtrlCInInsertModeStaysAsCopyAndReturnsToNormal(t *testing.T) {
 	disableAutoupdate(t)
 	dir := t.TempDir()
 	path := writeFile(t, dir, "z.txt", "line1\nline2\n")
-	m, err := NewModel(dir)
+	m, err := NewModel(dir, nil)
 	if err != nil {
 		t.Fatalf("NewModel: %v", err)
 	}
@@ -542,7 +543,7 @@ func TestE2E_CtrlQWithDirtyBufferFlushesBeforeExit(t *testing.T) {
 	disableAutoupdate(t)
 	dir := t.TempDir()
 	path := writeFile(t, dir, "q.txt", "seed\n")
-	m, err := NewModel(dir)
+	m, err := NewModel(dir, nil)
 	if err != nil {
 		t.Fatalf("NewModel: %v", err)
 	}
@@ -900,8 +901,9 @@ func TestE2E_LayoutInvariants(t *testing.T) {
 				//      editorWidth() doesn't subtract, so any two-pane scene
 				//      overhangs by 1 cell.
 				//   2. When the total width is near or below the tree pane
-				//      width (treeWidth=30), the editor's "at least 1 cell"
-				//      clamp pushes the overhang to 2 cells.
+				//      width (default 30, from config.Defaults()), the
+				//      editor's "at least 1 cell" clamp pushes the overhang
+				//      to 2 cells.
 				// The structural invariant the test actually enforces is "no
 				// runaway overflow" (e.g. a regression that renders the full
 				// path uncropped into the status bar).
@@ -912,7 +914,7 @@ func TestE2E_LayoutInvariants(t *testing.T) {
 					tolerance = 1
 					// Tiny widths: editor is clamped to min-1, border still
 					// adds 1, so total overhang is 2.
-					if w <= treeWidth {
+					if w <= config.Defaults().UI.TreeWidth {
 						tolerance = 2
 					}
 				}

--- a/internal/editor/model_init_test.go
+++ b/internal/editor/model_init_test.go
@@ -32,7 +32,7 @@ func TestNewModelEmitsInitializeAndRegistersAutoupdateCommands(t *testing.T) {
 
 	root := t.TempDir()
 
-	m, err := NewModel(root)
+	m, err := NewModel(root, nil)
 	if err != nil {
 		t.Fatalf("NewModel(%q): %v", root, err)
 	}

--- a/internal/editor/model_test.go
+++ b/internal/editor/model_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/kujtimiihoxha/vimtea"
 
+	"github.com/savimcio/nistru/internal/config"
 	"github.com/savimcio/nistru/plugin"
 )
 
@@ -271,9 +272,11 @@ func TestEditorWidth_WithAndWithoutLeftPane(t *testing.T) {
 		t.Errorf("no leftPane: got %d, want 100", got)
 	}
 
-	// With a left pane, the editor's width is width - treeWidth.
+	// With a left pane, the editor's width is width - tree-pane width.
+	// m.treeWidth() falls back to config.Defaults().UI.TreeWidth when
+	// m.cfg is nil — matching these hand-built Models.
 	m2 := &Model{width: 100, leftPane: stubPane{}}
-	want := 100 - treeWidth
+	want := 100 - config.Defaults().UI.TreeWidth
 	if got := m2.editorWidth(); got != want {
 		t.Errorf("with leftPane: got %d, want %d", got, want)
 	}

--- a/internal/editor/run.go
+++ b/internal/editor/run.go
@@ -4,13 +4,18 @@ import (
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/savimcio/nistru/internal/config"
 )
 
 // Run starts the editor's Bubble Tea program rooted at path and
 // guarantees a final autosave flush on exit. It is the single entry
 // point consumed by cmd/nistru.
-func Run(path string) error {
-	m, err := NewModel(path)
+//
+// A nil cfg is replaced with config.Defaults() so callers that haven't
+// wired in the loader yet still get a working editor.
+func Run(path string, cfg *config.Config) error {
+	m, err := NewModel(path, cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/plugins/autoupdate/autoupdate.go
+++ b/internal/plugins/autoupdate/autoupdate.go
@@ -17,6 +17,8 @@ package autoupdate
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -39,11 +41,22 @@ const (
 	shutdownGrace = 500 * time.Millisecond
 
 	// envRepo, envChannel, envInterval, envDisable are the environment-
-	// variable overrides honoured by New().
-	envRepo     = "NISTRU_AUTOUPDATE_REPO"
-	envChannel  = "NISTRU_AUTOUPDATE_CHANNEL"
+	// variable overrides honoured by handleInitialize. They sit above config
+	// but below constructor options in the precedence ladder so shell-side
+	// overrides remain an emergency kill switch.
+	//
+	// Deprecated: prefer the [plugins.autoupdate] TOML section. Env still wins
+	// as an emergency override.
+	envRepo = "NISTRU_AUTOUPDATE_REPO"
+	// Deprecated: prefer the [plugins.autoupdate] TOML section. Env still wins
+	// as an emergency override.
+	envChannel = "NISTRU_AUTOUPDATE_CHANNEL"
+	// Deprecated: prefer the [plugins.autoupdate] TOML section. Env still wins
+	// as an emergency override.
 	envInterval = "NISTRU_AUTOUPDATE_INTERVAL"
-	envDisable  = "NISTRU_AUTOUPDATE_DISABLE"
+	// Deprecated: prefer the [plugins.autoupdate] TOML section. Env still wins
+	// as an emergency override.
+	envDisable = "NISTRU_AUTOUPDATE_DISABLE"
 )
 
 // Installer is the seam T7 will fill with the real binary swap. The noop
@@ -64,6 +77,19 @@ type Plugin struct {
 	interval time.Duration
 	disabled bool
 
+	// optionSet records which fields were explicitly set via constructor
+	// options. OnConfig and applyEnv honour this bitset so options remain
+	// the highest-precedence source.
+	optionSet sourceBits
+
+	// configSet records which fields currently carry a value installed by a
+	// prior OnConfig call. On reload with nil/empty raw (the user removed
+	// the [plugins.autoupdate] section), OnConfig uses this set to know
+	// exactly which fields to revert to defaults, leaving option- and
+	// env-owned fields alone. Writes gated by p.mu like every other mutable
+	// field on this struct.
+	configSet sourceBits
+
 	client    *http.Client
 	installer Installer
 	now       func() time.Time
@@ -78,12 +104,24 @@ type Plugin struct {
 	ctxCancel context.CancelFunc
 }
 
+// sourceBits tracks which fields were set via constructor options. Precedence
+// (low → high): defaults → config (OnConfig) → env (applyEnv) → options.
+// A true bit means the field was set by an option; config and env leave it
+// alone.
+type sourceBits struct {
+	repo, channel, interval, disabled bool
+}
+
 // Option configures Plugin at construction.
 type Option func(*Plugin)
 
-// WithRepo overrides the "owner/repo" string polled for releases.
+// WithRepo overrides the "owner/repo" string polled for releases. Marks the
+// field as option-owned so OnConfig and env vars cannot overwrite it.
 func WithRepo(repo string) Option {
-	return func(p *Plugin) { p.repo = repo }
+	return func(p *Plugin) {
+		p.repo = repo
+		p.optionSet.repo = true
+	}
 }
 
 // WithHTTPClient injects a custom *http.Client (tests point it at an
@@ -109,11 +147,13 @@ func WithClock(now func() time.Time) Option {
 }
 
 // WithInterval overrides the ticker period. Tests use very short intervals
-// to exercise the loop without hanging.
+// to exercise the loop without hanging. Marks the field as option-owned so
+// OnConfig and env vars cannot overwrite it.
 func WithInterval(d time.Duration) Option {
 	return func(p *Plugin) {
 		if d > 0 {
 			p.interval = d
+			p.optionSet.interval = true
 		}
 	}
 }
@@ -143,10 +183,12 @@ func WithVersionFunc(fn func() string) Option {
 	}
 }
 
-// New returns a configured plugin with defaults filled in from the
-// environment. Env precedence: construction options > env vars > package
-// defaults. New never performs I/O; the background goroutine and state load
-// run inside OnEvent(Initialize).
+// New returns a configured plugin with defaults plus any supplied options
+// applied. Precedence (low → high) is: defaults → config (via OnConfig) →
+// env vars (applied in handleInitialize) → constructor options. Env and
+// config reads are deferred until handleInitialize so options always win
+// over both. New never performs I/O; the background goroutine and state
+// load run inside OnEvent(Initialize).
 func New(opts ...Option) *Plugin {
 	p := &Plugin{
 		name:     "autoupdate",
@@ -158,28 +200,164 @@ func New(opts ...Option) *Plugin {
 	}
 	p.installer = NewInstaller(WithStateUpdater(p.updateState))
 
-	// Env defaults are applied before explicit options so callers can still
-	// override them. Tests that want a deterministic environment should
-	// clear these vars via t.Setenv before constructing.
-	if v := strings.TrimSpace(os.Getenv(envRepo)); v != "" {
-		p.repo = v
-	}
-	if v := strings.TrimSpace(os.Getenv(envChannel)); v != "" {
-		p.channel = v
-	}
-	if v := strings.TrimSpace(os.Getenv(envInterval)); v != "" {
-		if d, err := time.ParseDuration(v); err == nil && d > 0 {
-			p.interval = d
-		}
-	}
-	if os.Getenv(envDisable) == "1" {
-		p.disabled = true
-	}
-
 	for _, opt := range opts {
 		opt(p)
 	}
 	return p
+}
+
+// OnConfig applies config values to any field not already set via a
+// constructor option. Env vars still win: they are applied after OnConfig
+// in handleInitialize. Safe to call before or after handleInitialize; if
+// called after, fields changed here only take effect on the next check.
+//
+// Nil/empty-raw reset: when raw is nil or zero-length, the plugin was
+// reloaded with [plugins.autoupdate] absent from config. Any field that was
+// previously set by OnConfig (tracked in p.configSet) is reverted to its
+// construction-time default, so removing config cleanly restores defaults
+// without leaking stale overrides into the next check. Fields set via
+// constructor options or env vars are left untouched — they sit higher in
+// the precedence ladder and OnConfig never owned them.
+func (p *Plugin) OnConfig(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		p.resetConfigFields()
+		return nil
+	}
+	// Shape is intentionally loose: unknown fields are ignored silently so
+	// future keys don't break older plugins.
+	var cfg struct {
+		Repo     *string `json:"repo,omitempty"`
+		Channel  *string `json:"channel,omitempty"`
+		Interval *string `json:"interval,omitempty"`
+		Disable  *bool   `json:"disable,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// For each field, track whether this call installed a value. A field
+	// whose key is absent from the current raw reverts to its default if a
+	// prior OnConfig had set it — mirroring the nil-raw reset path but
+	// scoped to just that field.
+	if p.optionSet.repo {
+		// Option-owned; OnConfig has no say.
+	} else if cfg.Repo != nil {
+		if v := strings.TrimSpace(*cfg.Repo); v != "" {
+			p.repo = v
+			p.configSet.repo = true
+		} else if p.configSet.repo {
+			// Empty/whitespace value after previously setting via config —
+			// treat as a reset so users can clear a stale override by
+			// writing repo = "" without deleting the whole section.
+			p.repo = defaultRepo
+			p.configSet.repo = false
+		}
+	} else if p.configSet.repo {
+		p.repo = defaultRepo
+		p.configSet.repo = false
+	}
+
+	if p.optionSet.channel {
+		// Option-owned.
+	} else if cfg.Channel != nil {
+		p.channel = strings.TrimSpace(*cfg.Channel)
+		p.configSet.channel = true
+	} else if p.configSet.channel {
+		p.channel = ""
+		p.configSet.channel = false
+	}
+
+	if p.optionSet.interval {
+		// Option-owned.
+	} else if cfg.Interval != nil {
+		s := strings.TrimSpace(*cfg.Interval)
+		if s != "" {
+			if d, err := time.ParseDuration(s); err == nil && d > 0 {
+				p.interval = d
+				p.configSet.interval = true
+			} else {
+				fmt.Fprintf(os.Stderr, "plugin/autoupdate: bad interval %q in config: %v\n", s, err)
+			}
+		}
+	} else if p.configSet.interval {
+		p.interval = defaultInterval
+		p.configSet.interval = false
+	}
+
+	if p.optionSet.disabled {
+		// Option-owned.
+	} else if cfg.Disable != nil {
+		p.disabled = *cfg.Disable
+		p.configSet.disabled = true
+	} else if p.configSet.disabled {
+		p.disabled = false
+		p.configSet.disabled = false
+	}
+	return nil
+}
+
+// resetConfigFields reverts every field currently flagged as config-owned
+// (p.configSet) back to its construction-time default, leaving option- and
+// env-owned fields untouched. Called from OnConfig when raw is nil/empty,
+// which signals that the [plugins.autoupdate] section was removed on reload.
+// Constants like defaultRepo and defaultInterval are the source of truth;
+// the empty channel and disabled=false match what New() installs before
+// options are applied.
+func (p *Plugin) resetConfigFields() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.configSet.repo && !p.optionSet.repo {
+		p.repo = defaultRepo
+	}
+	if p.configSet.channel && !p.optionSet.channel {
+		p.channel = ""
+	}
+	if p.configSet.interval && !p.optionSet.interval {
+		p.interval = defaultInterval
+	}
+	if p.configSet.disabled && !p.optionSet.disabled {
+		p.disabled = false
+	}
+	// Clear the bits regardless of option ownership — a field we could not
+	// reset is one that the option layer now owns anyway, and leaving the
+	// bit set would cause the next OnConfig to double-reset it.
+	p.configSet = sourceBits{}
+}
+
+// applyEnv reads the deprecated NISTRU_AUTOUPDATE_* env vars and overlays
+// them onto any field that was not set via a constructor option. Called at
+// the start of handleInitialize so env always wins over OnConfig but loses
+// to options. Callers must not hold p.mu — this helper acquires it.
+func applyEnv(p *Plugin) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.optionSet.repo {
+		if v := strings.TrimSpace(os.Getenv(envRepo)); v != "" {
+			p.repo = v
+		}
+	}
+	if !p.optionSet.channel {
+		if v := strings.TrimSpace(os.Getenv(envChannel)); v != "" {
+			p.channel = v
+		}
+	}
+	if !p.optionSet.interval {
+		if v := strings.TrimSpace(os.Getenv(envInterval)); v != "" {
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				p.interval = d
+			}
+		}
+	}
+	if !p.optionSet.disabled {
+		if os.Getenv(envDisable) == "1" {
+			p.disabled = true
+		}
+	}
 }
 
 // Name implements plugin.Plugin.
@@ -228,7 +406,22 @@ func (p *Plugin) Shutdown() error {
 // register commands (so the palette surfaces them and users can dispatch
 // install/rollback manually), but skip the background checker — "disabled"
 // refers to the polling loop, not the whole feature.
+//
+// applyEnv runs first so env vars overlay whatever OnConfig (fired earlier
+// from the host's Initialize dispatch) installed. Constructor options stay
+// untouched because the optionSet bits gate every write.
 func (p *Plugin) handleInitialize() {
+	applyEnv(p)
+
+	// Idempotency: handleInitialize may fire a second time after a settings
+	// reload (Host.ReEmitInitialize). Stop any prior checker goroutine before
+	// we potentially spawn a new one so reloads do not leak goroutines, and
+	// so a user flipping [plugins.autoupdate].disable = true in config then
+	// reloading actually silences the background poller. stopCheckerForReload
+	// does not flip p.shutdown — that is reserved for the permanent-shutdown
+	// path — so the re-spawn below still runs.
+	p.stopCheckerForReload()
+
 	p.mu.Lock()
 	if p.shutdown {
 		p.mu.Unlock()
@@ -594,6 +787,8 @@ func (p *Plugin) stopChecker() {
 	p.shutdown = true
 	cancel := p.ctxCancel
 	c := p.checker
+	p.checker = nil
+	p.ctxCancel = nil
 	inst := p.installer
 	p.mu.Unlock()
 
@@ -610,6 +805,35 @@ func (p *Plugin) stopChecker() {
 	}
 }
 
+// stopCheckerForReload cancels the background goroutine and waits for it to
+// exit (up to shutdownGrace) without flipping p.shutdown. Used from
+// handleInitialize to guarantee idempotency under Host.ReEmitInitialize so
+// a settings reload never leaks a goroutine or keeps a stale poller alive
+// after the user flipped [plugins.autoupdate].disable = true.
+//
+// Safe to call when no checker has ever been spawned — it is a no-op in
+// that case. Does not invoke the installer's Cleanup hook because this
+// path is not a permanent shutdown.
+func (p *Plugin) stopCheckerForReload() {
+	p.mu.Lock()
+	if p.shutdown {
+		p.mu.Unlock()
+		return
+	}
+	cancel := p.ctxCancel
+	c := p.checker
+	p.checker = nil
+	p.ctxCancel = nil
+	p.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if c != nil {
+		c.cancel(shutdownGrace)
+	}
+}
+
 // cleaner is the optional interface RealInstaller implements so the plugin
 // can garbage-collect stale ".prev" binaries on Shutdown.
 type cleaner interface {
@@ -618,6 +842,7 @@ type cleaner interface {
 
 // Compile-time assertions so a missing interface surfaces at build time.
 var (
-	_ plugin.Plugin    = (*Plugin)(nil)
-	_ plugin.HostAware = (*Plugin)(nil)
+	_ plugin.Plugin         = (*Plugin)(nil)
+	_ plugin.HostAware      = (*Plugin)(nil)
+	_ plugin.ConfigReceiver = (*Plugin)(nil)
 )

--- a/internal/plugins/autoupdate/autoupdate_test.go
+++ b/internal/plugins/autoupdate/autoupdate_test.go
@@ -2,6 +2,7 @@ package autoupdate
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -287,6 +288,365 @@ func TestExecuteInstallCallsInstaller(t *testing.T) {
 		defer inst.mu.Unlock()
 		return inst.rollbacks == 1
 	})
+}
+
+// TestPlugin_ConfigPrecedence exercises the three-way precedence ladder for
+// the autoupdate plugin's configuration sources: defaults < config (via
+// OnConfig) < env < constructor options.
+//
+// Every case drives the same flow: build a Plugin, optionally set env and/or
+// call OnConfig, then run handleInitialize (which applies env). The final
+// field values on p are the ground truth. A disabled checker (or a stub
+// HTTP transport + a tempdir state path) keeps these tests hermetic — the
+// background goroutine must not hit the network or leak past t.Cleanup.
+func TestPlugin_ConfigPrecedence(t *testing.T) {
+	type fields struct {
+		repo     string
+		channel  string
+		interval time.Duration
+		disabled bool
+	}
+
+	cases := []struct {
+		name      string
+		envRepo   string // "" means leave unset
+		envChan   string
+		envIntvl  string
+		envDis    string
+		config    string // raw JSON for OnConfig; "" means skip
+		extraOpts func(t *testing.T) []Option
+		want      fields
+	}{
+		{
+			name:   "config_alone",
+			config: `{"repo":"c/r","channel":"dev","interval":"2h","disable":true}`,
+			want: fields{
+				repo:     "c/r",
+				channel:  "dev",
+				interval: 2 * time.Hour,
+				disabled: true,
+			},
+		},
+		{
+			name:    "env_wins_over_config",
+			envRepo: "env/r",
+			config:  `{"repo":"cfg/r"}`,
+			want: fields{
+				repo:     "env/r",
+				channel:  "",
+				interval: defaultInterval,
+				disabled: false,
+			},
+		},
+		{
+			name:    "option_wins_over_both",
+			envRepo: "env/r",
+			config:  `{"repo":"cfg/r"}`,
+			extraOpts: func(_ *testing.T) []Option {
+				return []Option{WithRepo("opt/r")}
+			},
+			want: fields{
+				repo:     "opt/r",
+				channel:  "",
+				interval: defaultInterval,
+				disabled: false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Scrub env so parallel/serial runs are hermetic; then set per-case.
+			t.Setenv(envRepo, tc.envRepo)
+			t.Setenv(envChannel, tc.envChan)
+			t.Setenv(envInterval, tc.envIntvl)
+			t.Setenv(envDisable, tc.envDis)
+
+			// Stub transport so the checker goroutine doesn't try the real
+			// network even when the config doesn't disable it. An empty
+			// JSON array is a valid /releases payload.
+			client := &http.Client{
+				Transport: &stubTransport{body: []byte(`[]`)},
+				Timeout:   5 * time.Second,
+			}
+
+			statePath := filepath.Join(t.TempDir(), "s.json")
+			opts := []Option{
+				WithHTTPClient(client),
+				WithStatePath(statePath),
+				WithCurrent("v0.1.0"),
+			}
+			if tc.extraOpts != nil {
+				opts = append(opts, tc.extraOpts(t)...)
+			}
+
+			p := New(opts...)
+			// Teardown first so a half-initialised plugin still stops cleanly.
+			t.Cleanup(func() { _ = p.Shutdown() })
+
+			if tc.config != "" {
+				if err := p.OnConfig(json.RawMessage(tc.config)); err != nil {
+					t.Fatalf("OnConfig: %v", err)
+				}
+			}
+
+			// Drive env application + (possibly) checker spawn. The stub
+			// transport + tempdir state path keep it hermetic.
+			p.handleInitialize()
+
+			p.mu.Lock()
+			got := fields{
+				repo:     p.repo,
+				channel:  p.channel,
+				interval: p.interval,
+				disabled: p.disabled,
+			}
+			p.mu.Unlock()
+
+			if got != tc.want {
+				t.Fatalf("fields = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPlugin_Initialize_Idempotent verifies that a second handleInitialize
+// call — as happens after Host.ReEmitInitialize on a settings reload — does
+// not leak the previous checker goroutine. The earlier checker must be
+// cancelled and its goroutine exited before the new one spawns.
+func TestPlugin_Initialize_Idempotent(t *testing.T) {
+	srv, _ := newReleaseServerJSON(t, `[]`)
+	p := newTestPlugin(t, srv, "v0.1.0")
+	_ = newTestHost(t, p)
+
+	// First init: spawns checker #1.
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+	p.mu.Lock()
+	first := p.checker
+	p.mu.Unlock()
+	if first == nil {
+		t.Fatalf("first handleInitialize did not spawn a checker")
+	}
+
+	// Second init: must stop checker #1 and spawn checker #2. We wait on
+	// first.done to prove the goroutine actually exited — a leak would
+	// show up as this channel never closing.
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+	select {
+	case <-first.done:
+	case <-time.After(2 * shutdownGrace):
+		t.Fatalf("prior checker goroutine did not exit after re-initialize")
+	}
+
+	p.mu.Lock()
+	second := p.checker
+	p.mu.Unlock()
+	if second == nil {
+		t.Fatalf("second handleInitialize did not spawn a fresh checker")
+	}
+	if second == first {
+		t.Fatalf("second handleInitialize reused the stopped checker pointer")
+	}
+
+	// Shutdown must cleanly stop checker #2 and leave p.checker nil.
+	if err := p.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	select {
+	case <-second.done:
+	case <-time.After(2 * shutdownGrace):
+		t.Fatalf("current checker goroutine did not exit on Shutdown")
+	}
+	p.mu.Lock()
+	leaked := p.checker
+	p.mu.Unlock()
+	if leaked != nil {
+		t.Fatalf("Shutdown did not clear p.checker; got %p", leaked)
+	}
+}
+
+// TestPlugin_Initialize_Idempotent_DisabledAfterReload verifies the second
+// fix motivation: if the user flips `disable = true` in config and reloads,
+// the old checker is stopped and no new one is spawned.
+func TestPlugin_Initialize_Idempotent_DisabledAfterReload(t *testing.T) {
+	srv, _ := newReleaseServerJSON(t, `[]`)
+	p := newTestPlugin(t, srv, "v0.1.0")
+	_ = newTestHost(t, p)
+
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+	p.mu.Lock()
+	first := p.checker
+	p.mu.Unlock()
+	if first == nil {
+		t.Fatalf("first handleInitialize did not spawn a checker")
+	}
+
+	// Simulate a reload where config now disables the poller.
+	if err := p.OnConfig(json.RawMessage(`{"disable":true}`)); err != nil {
+		t.Fatalf("OnConfig: %v", err)
+	}
+	_ = p.OnEvent(plugin.Initialize{RootPath: t.TempDir()})
+
+	select {
+	case <-first.done:
+	case <-time.After(2 * shutdownGrace):
+		t.Fatalf("prior checker goroutine did not exit after disable+reload")
+	}
+	p.mu.Lock()
+	stillRunning := p.checker
+	p.mu.Unlock()
+	if stillRunning != nil {
+		t.Fatalf("checker still running after disable=true reload: %p", stillRunning)
+	}
+}
+
+// TestPlugin_OnConfig_Nil_ResetsConfigFields covers the Host.ReEmitInitialize
+// reload path where a user has removed the [plugins.autoupdate] section
+// entirely: the host now invokes OnConfig(nil) and the plugin must revert
+// every field previously set via config back to its construction-time
+// default, leaving option- and env-owned fields alone.
+func TestPlugin_OnConfig_Nil_ResetsConfigFields(t *testing.T) {
+	// Scrub env so this test is hermetic — env vars would otherwise pin
+	// fields above the config layer and defeat the reset check.
+	t.Setenv(envDisable, "")
+	t.Setenv(envRepo, "")
+	t.Setenv(envChannel, "")
+	t.Setenv(envInterval, "")
+
+	p := New()
+	t.Cleanup(func() { _ = p.Shutdown() })
+
+	// Seed repo+interval+channel+disable via config; the field values should
+	// then reflect the config payload.
+	payload := `{"repo":"x/y","channel":"dev","interval":"2h","disable":true}`
+	if err := p.OnConfig(json.RawMessage(payload)); err != nil {
+		t.Fatalf("OnConfig(payload): %v", err)
+	}
+	p.mu.Lock()
+	gotRepo := p.repo
+	gotChan := p.channel
+	gotIntvl := p.interval
+	gotDis := p.disabled
+	p.mu.Unlock()
+	if gotRepo != "x/y" {
+		t.Fatalf("after payload, repo = %q, want x/y", gotRepo)
+	}
+	if gotChan != "dev" {
+		t.Fatalf("after payload, channel = %q, want dev", gotChan)
+	}
+	if gotIntvl != 2*time.Hour {
+		t.Fatalf("after payload, interval = %s, want 2h", gotIntvl)
+	}
+	if !gotDis {
+		t.Fatalf("after payload, disabled = false, want true")
+	}
+
+	// Now the user deletes [plugins.autoupdate] and reloads; the host calls
+	// OnConfig(nil). Every field the prior OnConfig wrote must revert to
+	// its construction-time default.
+	if err := p.OnConfig(nil); err != nil {
+		t.Fatalf("OnConfig(nil): %v", err)
+	}
+	p.mu.Lock()
+	gotRepo = p.repo
+	gotChan = p.channel
+	gotIntvl = p.interval
+	gotDis = p.disabled
+	p.mu.Unlock()
+	if gotRepo != defaultRepo {
+		t.Fatalf("after OnConfig(nil), repo = %q, want %q", gotRepo, defaultRepo)
+	}
+	if gotChan != "" {
+		t.Fatalf("after OnConfig(nil), channel = %q, want empty", gotChan)
+	}
+	if gotIntvl != defaultInterval {
+		t.Fatalf("after OnConfig(nil), interval = %s, want %s", gotIntvl, defaultInterval)
+	}
+	if gotDis {
+		t.Fatalf("after OnConfig(nil), disabled = true, want false")
+	}
+
+	// Zero-length raw (json.RawMessage{}) must take the same reset path.
+	if err := p.OnConfig(json.RawMessage(payload)); err != nil {
+		t.Fatalf("OnConfig(restore): %v", err)
+	}
+	if err := p.OnConfig(json.RawMessage{}); err != nil {
+		t.Fatalf("OnConfig(empty): %v", err)
+	}
+	p.mu.Lock()
+	gotRepo = p.repo
+	gotDis = p.disabled
+	p.mu.Unlock()
+	if gotRepo != defaultRepo {
+		t.Fatalf("after OnConfig(empty), repo = %q, want %q", gotRepo, defaultRepo)
+	}
+	if gotDis {
+		t.Fatalf("after OnConfig(empty), disabled = true, want false")
+	}
+}
+
+// TestPlugin_OnConfig_Nil_LeavesOptionsAlone asserts the reset path respects
+// the precedence ladder: fields set via constructor options must not be
+// overwritten by the nil-raw reset.
+func TestPlugin_OnConfig_Nil_LeavesOptionsAlone(t *testing.T) {
+	t.Setenv(envDisable, "")
+	t.Setenv(envRepo, "")
+	t.Setenv(envChannel, "")
+	t.Setenv(envInterval, "")
+
+	p := New(WithRepo("opt/repo"), WithInterval(3*time.Hour))
+	t.Cleanup(func() { _ = p.Shutdown() })
+
+	// Config tries to override both, but options win.
+	if err := p.OnConfig(json.RawMessage(`{"repo":"cfg/r","interval":"5h"}`)); err != nil {
+		t.Fatalf("OnConfig: %v", err)
+	}
+	// Now remove config: option-owned fields must stay put.
+	if err := p.OnConfig(nil); err != nil {
+		t.Fatalf("OnConfig(nil): %v", err)
+	}
+	p.mu.Lock()
+	gotRepo := p.repo
+	gotIntvl := p.interval
+	p.mu.Unlock()
+	if gotRepo != "opt/repo" {
+		t.Fatalf("after OnConfig(nil), repo = %q, want opt/repo (option)", gotRepo)
+	}
+	if gotIntvl != 3*time.Hour {
+		t.Fatalf("after OnConfig(nil), interval = %s, want 3h (option)", gotIntvl)
+	}
+}
+
+// TestPlugin_OnConfig_FieldRemoval_Resets asserts the key-absence reset at
+// field granularity: if a [plugins.autoupdate] section is present but a
+// previously-set key (e.g. interval) is deleted, OnConfig reverts that field
+// to its default rather than retaining the stale value.
+func TestPlugin_OnConfig_FieldRemoval_Resets(t *testing.T) {
+	t.Setenv(envDisable, "")
+	t.Setenv(envRepo, "")
+	t.Setenv(envChannel, "")
+	t.Setenv(envInterval, "")
+
+	p := New()
+	t.Cleanup(func() { _ = p.Shutdown() })
+
+	if err := p.OnConfig(json.RawMessage(`{"repo":"x/y","interval":"2h"}`)); err != nil {
+		t.Fatalf("OnConfig(seed): %v", err)
+	}
+	// User edits the section to remove interval only; repo survives.
+	if err := p.OnConfig(json.RawMessage(`{"repo":"x/y"}`)); err != nil {
+		t.Fatalf("OnConfig(drop interval): %v", err)
+	}
+	p.mu.Lock()
+	gotRepo := p.repo
+	gotIntvl := p.interval
+	p.mu.Unlock()
+	if gotRepo != "x/y" {
+		t.Fatalf("repo clobbered on partial reload: got %q, want x/y", gotRepo)
+	}
+	if gotIntvl != defaultInterval {
+		t.Fatalf("interval not reset on key removal: got %s, want %s", gotIntvl, defaultInterval)
+	}
 }
 
 func TestShutdownStopsCheckerCleanly(t *testing.T) {

--- a/internal/plugins/settingscmd/settingscmd.go
+++ b/internal/plugins/settingscmd/settingscmd.go
@@ -1,0 +1,219 @@
+// Package settingscmd is the first-party in-proc plugin that owns the
+// palette commands for inspecting and reloading Nistru's layered TOML
+// configuration. Its four commands mirror the four things a user wants
+// to do after editing settings:
+//
+//   - nistru.settings.openUser     — open ~/.config/nistru/config.toml
+//   - nistru.settings.openProject  — open <root>/.nistru/config.toml
+//   - nistru.settings.reload       — reparse both files + re-emit per-plugin config
+//   - nistru.settings.showResolved — dump the fully-merged config to a temp file
+//
+// The plugin owns no state beyond the host handle and the config getter;
+// the reload flow is driven by the editor Model, which intercepts the
+// plugin.ReloadConfigRequest effect the reload command emits.
+package settingscmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/savimcio/nistru/internal/config"
+	"github.com/savimcio/nistru/plugin"
+)
+
+// Command IDs. Namespaced under nistru.settings.* so they fit alongside
+// the autoupdate plugin's nistru.autoupdate.* space.
+const (
+	cmdOpenUser     = "nistru.settings.openUser"
+	cmdOpenProject  = "nistru.settings.openProject"
+	cmdReload       = "nistru.settings.reload"
+	cmdShowResolved = "nistru.settings.showResolved"
+)
+
+// Plugin is the settings orchestration plugin: it owns palette commands
+// for opening, reloading, and inspecting the merged configuration.
+type Plugin struct {
+	host   *plugin.Host
+	root   string
+	getCfg func() *config.Config
+}
+
+// New constructs a plugin rooted at the workspace root. getCfg returns the
+// live *config.Config at call time so showResolved reflects the current
+// post-reload state. getCfg must never be nil.
+func New(root string, getCfg func() *config.Config) *Plugin {
+	return &Plugin{root: root, getCfg: getCfg}
+}
+
+// Name implements plugin.Plugin.
+func (p *Plugin) Name() string { return "settings" }
+
+// Activation implements plugin.Plugin. The four palette commands must be
+// available from the moment the editor boots, so we activate onStart.
+func (p *Plugin) Activation() []string { return []string{"onStart"} }
+
+// SetHost implements plugin.HostAware. Called once by the host before
+// Initialize is dispatched.
+func (p *Plugin) SetHost(h *plugin.Host) { p.host = h }
+
+// OnEvent implements plugin.Plugin. Initialize registers the palette
+// commands via PostNotif (mirrors autoupdate's pattern). ExecuteCommand
+// dispatches to the per-command handler and returns its effects.
+func (p *Plugin) OnEvent(ev any) []plugin.Effect {
+	switch e := ev.(type) {
+	case plugin.Initialize:
+		p.registerCommands()
+		return nil
+	case plugin.ExecuteCommand:
+		return p.dispatch(e)
+	}
+	return nil
+}
+
+// Shutdown implements plugin.Plugin. The plugin owns no background work,
+// so teardown is a no-op.
+func (p *Plugin) Shutdown() error { return nil }
+
+// registerCommands fires four commands/register notifications via
+// PostNotif; the host applies them synchronously so the palette picks
+// them up on the very next frame.
+func (p *Plugin) registerCommands() {
+	if p.host == nil {
+		return
+	}
+	cmds := []struct {
+		id, title string
+	}{
+		{cmdOpenUser, "Nistru: Open User Settings"},
+		{cmdOpenProject, "Nistru: Open Project Settings"},
+		{cmdReload, "Nistru: Reload Settings"},
+		{cmdShowResolved, "Nistru: Show Resolved Config"},
+	}
+	for _, c := range cmds {
+		_ = p.host.PostNotif("settings", "commands/register", map[string]string{
+			"id":    c.id,
+			"title": c.title,
+		})
+	}
+}
+
+// dispatch routes an ExecuteCommand to its handler. Handlers return
+// []plugin.Effect so OnEvent can surface them up to the host.
+func (p *Plugin) dispatch(ev plugin.ExecuteCommand) []plugin.Effect {
+	switch ev.ID {
+	case cmdOpenUser:
+		return p.openUser()
+	case cmdOpenProject:
+		return p.openProject()
+	case cmdReload:
+		return p.reload()
+	case cmdShowResolved:
+		return p.showResolved()
+	}
+	return nil
+}
+
+// openUser resolves the per-user config path, seeds it with the commented
+// defaults skeleton when absent, and asks the editor to open it.
+func (p *Plugin) openUser() []plugin.Effect {
+	path, err := config.UserPath()
+	if err != nil {
+		return errNotify(err)
+	}
+	if err := ensureSeeded(path, config.CommentedDefaults()); err != nil {
+		return errNotify(err)
+	}
+	return []plugin.Effect{plugin.OpenFile{Path: path}}
+}
+
+// openProject resolves the per-project config path, seeds it with the
+// commented defaults skeleton when absent, and asks the editor to open it.
+func (p *Plugin) openProject() []plugin.Effect {
+	path := config.ProjectPath(p.root)
+	if err := ensureSeeded(path, config.CommentedDefaults()); err != nil {
+		return errNotify(err)
+	}
+	return []plugin.Effect{plugin.OpenFile{Path: path}}
+}
+
+// reload emits the sentinel effect the Model intercepts to reparse the
+// config files + re-emit per-plugin config. Paired with a user-facing
+// ui/notify so the status bar acknowledges the request.
+func (p *Plugin) reload() []plugin.Effect {
+	return []plugin.Effect{
+		plugin.ReloadConfigRequest{},
+		plugin.Notify{Level: "info", Message: "Reloading settings…"},
+	}
+}
+
+// showResolved marshals the fully-merged config to TOML, writes it under
+// <root>/.nistru/.resolved-config.toml, and opens that file in the editor.
+// The dotfile name is deliberate — it's an inspection artefact, not a
+// source of truth.
+func (p *Plugin) showResolved() []plugin.Effect {
+	cfg := p.getCfg()
+	if cfg == nil {
+		return errNotify(fmt.Errorf("settings: no config loaded"))
+	}
+	data, err := cfg.EncodeResolved()
+	if err != nil {
+		return errNotify(err)
+	}
+	path := filepath.Join(p.root, ".nistru", ".resolved-config.toml")
+	if err := writeAtomic(path, data); err != nil {
+		return errNotify(err)
+	}
+	return []plugin.Effect{plugin.OpenFile{Path: path}}
+}
+
+// ensureSeeded writes seed to path iff the file does not already exist.
+// The parent directory is created with 0755. Existing files are left
+// untouched so user edits never get clobbered by a palette command.
+func ensureSeeded(path, seed string) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("settings: stat %s: %w", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("settings: mkdir %s: %w", filepath.Dir(path), err)
+	}
+	return writeAtomic(path, []byte(seed))
+}
+
+// writeAtomic writes data to path via a sibling .tmp file followed by
+// os.Rename. Mirrors internal/editor/autosave.go's atomicWriteFile so a
+// crash mid-write cannot leave a half-written file. Duplicated here to
+// avoid an editor→settingscmd layering inversion.
+func writeAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("settings: mkdir %s: %w", filepath.Dir(path), err)
+	}
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, mode); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("settings: write tmp %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("settings: rename %s: %w", path, err)
+	}
+	return nil
+}
+
+// errNotify wraps err as a single Notify effect. The framework expects
+// command handlers to surface errors via effects, not returns.
+func errNotify(err error) []plugin.Effect {
+	return []plugin.Effect{plugin.Notify{Level: "error", Message: err.Error()}}
+}
+
+// Compile-time assertions so a missing interface surfaces at build time.
+var (
+	_ plugin.Plugin    = (*Plugin)(nil)
+	_ plugin.HostAware = (*Plugin)(nil)
+)

--- a/internal/plugins/settingscmd/settingscmd_test.go
+++ b/internal/plugins/settingscmd/settingscmd_test.go
@@ -1,0 +1,199 @@
+package settingscmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/savimcio/nistru/internal/config"
+	"github.com/savimcio/nistru/plugin"
+)
+
+// newTestPlugin builds a settingscmd plugin wired to an in-proc host so
+// SetHost + Initialize land the same way they do in production. Returns
+// the plugin + host so callers can invoke ExecuteCommand synchronously.
+func newTestPlugin(t *testing.T, root string, cfg *config.Config) *Plugin {
+	t.Helper()
+	if cfg == nil {
+		cfg = config.Defaults()
+	}
+	p := New(root, func() *config.Config { return cfg })
+	reg := plugin.NewRegistry()
+	reg.RegisterInProc(p)
+	h := plugin.NewHost(reg)
+	if err := h.Start(root); err != nil {
+		t.Fatalf("host.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Shutdown(0) })
+	// Initialize drives registerCommands via PostNotif.
+	h.Emit(plugin.Initialize{RootPath: root})
+	return p
+}
+
+// runCommand invokes the named command through the plugin's OnEvent
+// ExecuteCommand branch and returns the collected effects. Skips the host
+// dispatch layer so tests exercise the plugin in isolation.
+func runCommand(p *Plugin, id string) []plugin.Effect {
+	return p.OnEvent(plugin.ExecuteCommand{ID: id})
+}
+
+// TestOpenUser_CreatesSkeletonWhenMissing asserts the openUser command
+// creates <UserConfigDir>/nistru/config.toml when it does not already
+// exist, seeding it with the commented-defaults skeleton. The test
+// redirects UserConfigDir via $XDG_CONFIG_HOME so nothing escapes to the
+// real user config tree.
+func TestOpenUser_CreatesSkeletonWhenMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	// Belt-and-suspenders for non-Linux: Go's UserConfigDir honours
+	// HOME/LocalAppData on other OSes. Point HOME at the same tmp so the
+	// darwin path (~/Library/Application Support) still lands under tmp.
+	t.Setenv("HOME", tmp)
+
+	p := newTestPlugin(t, t.TempDir(), nil)
+
+	effs := runCommand(p, cmdOpenUser)
+	if len(effs) != 1 {
+		t.Fatalf("openUser effects = %d, want 1: %+v", len(effs), effs)
+	}
+	of, ok := effs[0].(plugin.OpenFile)
+	if !ok {
+		t.Fatalf("effect[0] = %T, want plugin.OpenFile", effs[0])
+	}
+
+	// The file must now exist on disk.
+	if _, err := os.Stat(of.Path); err != nil {
+		t.Fatalf("openUser did not seed %s: %v", of.Path, err)
+	}
+	body, err := os.ReadFile(of.Path)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	// The skeleton advertises every section; "tree_width" is a tight
+	// marker (the ui section exists and is spelled correctly).
+	if !strings.Contains(string(body), "tree_width") {
+		t.Fatalf("skeleton missing tree_width; body=%q", body)
+	}
+}
+
+// TestOpenUser_PreservesExistingFile guarantees the seeding logic never
+// clobbers an existing file. Regression guard: a user who has already
+// customised their config would lose it if this slipped.
+func TestOpenUser_PreservesExistingFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("HOME", tmp)
+
+	// Seed the file with a sentinel before running the command.
+	path, err := config.UserPath()
+	if err != nil {
+		t.Fatalf("UserPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	want := "# hand-written\ntree_width = 99\n"
+	if err := os.WriteFile(path, []byte(want), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	p := newTestPlugin(t, t.TempDir(), nil)
+	_ = runCommand(p, cmdOpenUser)
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("openUser overwrote existing file: got %q, want %q", got, want)
+	}
+}
+
+// TestOpenProject_CreatesSkeletonWhenMissing mirrors the openUser test
+// for the per-project path. No env manipulation needed — the path is
+// computed from p.root.
+func TestOpenProject_CreatesSkeletonWhenMissing(t *testing.T) {
+	root := t.TempDir()
+	p := newTestPlugin(t, root, nil)
+
+	effs := runCommand(p, cmdOpenProject)
+	if len(effs) != 1 {
+		t.Fatalf("openProject effects = %d, want 1", len(effs))
+	}
+	of, ok := effs[0].(plugin.OpenFile)
+	if !ok {
+		t.Fatalf("effect[0] = %T, want plugin.OpenFile", effs[0])
+	}
+	if of.Path != config.ProjectPath(root) {
+		t.Fatalf("openProject path = %q, want %q", of.Path, config.ProjectPath(root))
+	}
+	if _, err := os.Stat(of.Path); err != nil {
+		t.Fatalf("project file not created: %v", err)
+	}
+}
+
+// TestShowResolved_WritesMergedToml asserts showResolved serialises the
+// merged config to <root>/.nistru/.resolved-config.toml and returns the
+// corresponding OpenFile effect. The output must be valid TOML with the
+// expected top-level sections.
+func TestShowResolved_WritesMergedToml(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Defaults()
+	p := newTestPlugin(t, root, cfg)
+
+	effs := runCommand(p, cmdShowResolved)
+	if len(effs) != 1 {
+		t.Fatalf("showResolved effects = %d, want 1", len(effs))
+	}
+	of, ok := effs[0].(plugin.OpenFile)
+	if !ok {
+		t.Fatalf("effect[0] = %T, want plugin.OpenFile", effs[0])
+	}
+	wantPath := filepath.Join(root, ".nistru", ".resolved-config.toml")
+	if of.Path != wantPath {
+		t.Fatalf("showResolved path = %q, want %q", of.Path, wantPath)
+	}
+	body, err := os.ReadFile(of.Path)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	// The merged TOML always has a [keymap] section because DefaultKeymap
+	// is non-empty. Sanity-check on that.
+	if !strings.Contains(string(body), "[keymap]") {
+		t.Fatalf("resolved TOML missing [keymap]; body=%q", body)
+	}
+}
+
+// TestReload_ReturnsReloadEffect asserts the reload command returns
+// plugin.ReloadConfigRequest so the Model knows to reparse configuration.
+// A companion Notify is also returned; both must be present.
+func TestReload_ReturnsReloadEffect(t *testing.T) {
+	p := newTestPlugin(t, t.TempDir(), nil)
+
+	effs := runCommand(p, cmdReload)
+	if len(effs) != 2 {
+		t.Fatalf("reload effects = %d, want 2: %+v", len(effs), effs)
+	}
+	if _, ok := effs[0].(plugin.ReloadConfigRequest); !ok {
+		t.Fatalf("effect[0] = %T, want plugin.ReloadConfigRequest", effs[0])
+	}
+	n, ok := effs[1].(plugin.Notify)
+	if !ok {
+		t.Fatalf("effect[1] = %T, want plugin.Notify", effs[1])
+	}
+	if n.Message == "" {
+		t.Fatalf("reload Notify message empty")
+	}
+}
+
+// TestUnknownCommand_ReturnsNoEffects guards against accidental default
+// behaviour — unknown IDs must be a clean no-op rather than returning a
+// stale effect from the last match.
+func TestUnknownCommand_ReturnsNoEffects(t *testing.T) {
+	p := newTestPlugin(t, t.TempDir(), nil)
+
+	if effs := runCommand(p, "nistru.settings.doesNotExist"); len(effs) != 0 {
+		t.Fatalf("unknown command produced effects: %+v", effs)
+	}
+}

--- a/internal/plugins/treepane/treepane.go
+++ b/internal/plugins/treepane/treepane.go
@@ -7,6 +7,7 @@
 package treepane
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"sort"
@@ -17,14 +18,21 @@ import (
 	"github.com/savimcio/nistru/plugin"
 )
 
-// skipDirs is the hardcoded list of directory names we refuse to descend into.
-// Anything hidden (prefix ".") is also skipped except the root itself.
-var skipDirs = map[string]struct{}{
-	".git":         {},
-	"node_modules": {},
-	"vendor":       {},
-	"dist":         {},
-	"build":        {},
+// defaultSkipDirs is the baseline list of directory names we refuse to descend
+// into when no [plugins.treepane].skip_dirs override is supplied. Anything
+// hidden (prefix ".") is also skipped except the root itself. This list is
+// the in-code source of truth mirrored by the commented example in the
+// [plugins.treepane] skeleton — keep the two in sync.
+var defaultSkipDirs = []string{".git", "node_modules", "vendor", "dist", "build"}
+
+// makeSkipSet turns a slice of directory names into the set form walkDir
+// expects. Empty slice yields an empty set (nothing gets filtered by name).
+func makeSkipSet(dirs []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(dirs))
+	for _, d := range dirs {
+		out[d] = struct{}{}
+	}
+	return out
 }
 
 // row is one fully pre-rendered line of the tree. `prefix` contains the
@@ -50,13 +58,15 @@ type fsNode struct {
 
 // buildFsTree walks the directory at root and returns the fully constructed
 // fsNode tree. Every real directory starts collapsed; the synthetic top-level
-// wrapper is expanded so its children are visible at launch.
-func buildFsTree(root string) (*fsNode, error) {
+// wrapper is expanded so its children are visible at launch. The skip argument
+// is the per-invocation set of directory basenames to skip; pass nil to skip
+// nothing (hidden entries are still filtered by the walker itself).
+func buildFsTree(root string, skip map[string]struct{}) (*fsNode, error) {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
 		return nil, err
 	}
-	children, err := walkDir(absRoot, true)
+	children, err := walkDir(absRoot, true, skip)
 	if err != nil {
 		return nil, err
 	}
@@ -73,10 +83,13 @@ func buildFsTree(root string) (*fsNode, error) {
 
 // walkDir reads dir and returns its children as *fsNode values. isRoot tells
 // us whether to honour the "skip hidden" rule (we always descend into the
-// root even if its own name starts with "."). Errors for individual entries
-// are swallowed silently — a read-protected sub-tree shouldn't bring the UI
-// down — but errors on the top-level read are propagated.
-func walkDir(dir string, isRoot bool) ([]*fsNode, error) {
+// root even if its own name starts with "."). skip is the per-invocation set
+// of basenames to filter out — passed as a parameter rather than read from a
+// package-level var so the pane can honour user-supplied overrides on reload.
+// Errors for individual entries are swallowed silently — a read-protected
+// sub-tree shouldn't bring the UI down — but errors on the top-level read are
+// propagated.
+func walkDir(dir string, isRoot bool, skip map[string]struct{}) ([]*fsNode, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if isRoot {
@@ -89,7 +102,7 @@ func walkDir(dir string, isRoot bool) ([]*fsNode, error) {
 	var dirs, files []os.DirEntry
 	for _, e := range entries {
 		name := e.Name()
-		if _, skip := skipDirs[name]; skip {
+		if _, dropped := skip[name]; dropped {
 			continue
 		}
 		if strings.HasPrefix(name, ".") {
@@ -114,7 +127,7 @@ func walkDir(dir string, isRoot bool) ([]*fsNode, error) {
 
 	nodes := make([]*fsNode, 0, len(dirs)+len(files))
 	for _, d := range dirs {
-		sub, _ := walkDir(filepath.Join(dir, d.Name()), false)
+		sub, _ := walkDir(filepath.Join(dir, d.Name()), false, skip)
 		nodes = append(nodes, &fsNode{
 			path:     filepath.Join(dir, d.Name()),
 			label:    d.Name(),
@@ -508,25 +521,31 @@ func truncateToWidth(s string, width int) string {
 // TreePane is the exported wrapper that implements both plugin.Plugin and
 // plugin.Pane. It owns a treeModel and forwards pane lifecycle calls into it
 // while translating transport-neutral KeyEvents into the string keys that
-// treeModel.Update expects.
+// treeModel.Update expects. skipDirs is the currently-effective set of
+// directory basenames to filter from the walker — initialized from
+// defaultSkipDirs and rewritten by OnConfig.
 type TreePane struct {
-	model   treeModel
-	root    string
-	w, h    int
-	focused bool
+	model    treeModel
+	root     string
+	skipDirs map[string]struct{}
+	w, h     int
+	focused  bool
 }
 
 // New constructs a TreePane rooted at rootPath. It builds the full filesystem
 // tree eagerly, matching the previous behavior. Returns an error if the root
-// directory cannot be read.
+// directory cannot be read. The initial skip set is defaultSkipDirs; a later
+// OnConfig may replace it.
 func New(rootPath string) (*TreePane, error) {
-	node, err := buildFsTree(rootPath)
+	skip := makeSkipSet(defaultSkipDirs)
+	node, err := buildFsTree(rootPath, skip)
 	if err != nil {
 		return nil, err
 	}
 	return &TreePane{
-		model: newTreeModel(node, 1, 1),
-		root:  rootPath,
+		model:    newTreeModel(node, 1, 1),
+		root:     rootPath,
+		skipDirs: skip,
 	}, nil
 }
 
@@ -538,8 +557,80 @@ func (p *TreePane) Name() string { return "treepane" }
 // with the wire protocol.
 func (p *TreePane) Activation() []string { return []string{"onStart"} }
 
-// OnEvent is a no-op in v1; the tree does not react to buffer events.
-func (p *TreePane) OnEvent(event any) []plugin.Effect { return nil }
+// OnEvent is a no-op in v1 for most events; the tree does not react to buffer
+// events. Initialize is the one exception — it's the signal that config has
+// settled and any skip_dirs change from OnConfig should be materialised into
+// the on-screen tree.
+func (p *TreePane) OnEvent(event any) []plugin.Effect {
+	if _, ok := event.(plugin.Initialize); ok {
+		p.rebuildTree()
+	}
+	return nil
+}
+
+// OnConfig is the plugin.ConfigReceiver entrypoint. The host calls it just
+// before Initialize on first activation and again on every reload. We accept
+// a single optional key:
+//
+//	[plugins.treepane]
+//	skip_dirs = [".git", "dist"]   # absent -> reset to defaults; [] -> skip nothing
+//
+// The contract is "OnConfig represents the effective config at this moment".
+// If skip_dirs is absent — whether because the whole [plugins.treepane]
+// section was removed (raw is nil/empty) or only the skip_dirs line was
+// deleted from an otherwise-present section (raw is non-nil but the key is
+// absent) — the skip set resets to defaultSkipDirs. This matches the
+// ConfigReceiver nil-raw contract documented on plugin.ConfigReceiver and
+// ensures users who delete config see the in-code defaults return rather
+// than stale state from a previous load.
+//
+// The rebuild is deferred to the following OnEvent(Initialize) because that's
+// where the host's reload path normally drives UI refresh; doing it here as
+// well would rebuild twice on first boot.
+func (p *TreePane) OnConfig(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		// Config section absent entirely — reset to the in-code defaults.
+		p.skipDirs = makeSkipSet(defaultSkipDirs)
+		return nil
+	}
+	var cfg struct {
+		SkipDirs *[]string `json:"skip_dirs"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return err
+	}
+	if cfg.SkipDirs == nil {
+		// Key absent from an otherwise-present section — treat as "no
+		// override", which means the baseline defaults apply.
+		p.skipDirs = makeSkipSet(defaultSkipDirs)
+		return nil
+	}
+	// Explicit value supplied (possibly an empty array, meaning "skip
+	// nothing"). Replace the skip set; the following OnEvent(Initialize) will
+	// rebuild the tree against the new set.
+	p.skipDirs = makeSkipSet(*cfg.SkipDirs)
+	return nil
+}
+
+// rebuildTree reconstructs the fsNode tree from disk using the plugin's
+// current skip set and swaps it into the underlying treeModel. Errors are
+// swallowed — a transient read failure should not leave the pane with a nil
+// root. The treeModel's size is preserved so the repaint lines up with the
+// existing viewport.
+func (p *TreePane) rebuildTree() {
+	node, err := buildFsTree(p.root, p.skipDirs)
+	if err != nil {
+		return
+	}
+	w, h := p.w, p.h
+	if w < 1 {
+		w = 1
+	}
+	if h < 1 {
+		h = 1
+	}
+	p.model = newTreeModel(node, w, h)
+}
 
 // Shutdown releases resources. The tree has none.
 func (p *TreePane) Shutdown() error { return nil }

--- a/internal/plugins/treepane/treepane_test.go
+++ b/internal/plugins/treepane/treepane_test.go
@@ -1,6 +1,7 @@
 package treepane
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -433,6 +434,124 @@ func TestTreePane_WidthResponsive(t *testing.T) {
 				t.Fatalf("width %d: missing expanded marker ▾ in:\n%s", w, out)
 			}
 		})
+	}
+}
+
+// TestPlugin_OnConfig_RebuildsTree exercises the ConfigReceiver path: an
+// explicit empty skip_dirs array must stop node_modules from being hidden on
+// the next Initialize. This covers both config plumbing (OnConfig parses the
+// array) and the deferred rebuild (OnEvent(Initialize) re-walks the fs). The
+// inverse case — trimming the default set to exclude vendor, for example — is
+// covered transitively because the same code path runs.
+func TestPlugin_OnConfig_RebuildsTree(t *testing.T) {
+	root := buildFixture(t, map[string]string{
+		"node_modules/":         "",
+		"node_modules/pkg.json": "{}",
+		"src/":                  "",
+		"src/main.go":           "package main",
+	})
+	p, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Default skip set hides node_modules.
+	out := p.Render(80, 20)
+	if strings.Contains(out, "node_modules") {
+		t.Fatalf("default render unexpectedly shows node_modules:\n%s", out)
+	}
+
+	// Explicit empty array == skip nothing. Call OnConfig then re-fire
+	// Initialize the way the host would on reload.
+	if err := p.OnConfig([]byte(`{"skip_dirs":[]}`)); err != nil {
+		t.Fatalf("OnConfig: %v", err)
+	}
+	// OnConfig only swaps the skip set; OnEvent(Initialize) drives the
+	// rebuild — exactly the sequence Host.ReEmitInitialize produces.
+	p.OnEvent(plugin.Initialize{RootPath: root})
+
+	out = p.Render(80, 20)
+	if !strings.Contains(out, "node_modules") {
+		t.Fatalf("after skip_dirs=[] render missing node_modules:\n%s", out)
+	}
+	if !strings.Contains(out, "src") {
+		t.Fatalf("after reload render missing src/:\n%s", out)
+	}
+
+	// Omitting skip_dirs on a subsequent reload resets the set back to the
+	// defaults — the ConfigReceiver contract is "OnConfig represents the
+	// effective config at this moment; absent = default".
+	if err := p.OnConfig([]byte(`{}`)); err != nil {
+		t.Fatalf("OnConfig empty: %v", err)
+	}
+	p.OnEvent(plugin.Initialize{RootPath: root})
+	out = p.Render(80, 20)
+	if strings.Contains(out, "node_modules") {
+		t.Fatalf("omitted skip_dirs did not reset to defaults (node_modules still visible):\n%s", out)
+	}
+	if !strings.Contains(out, "src") {
+		t.Fatalf("after reset render missing src/:\n%s", out)
+	}
+
+	// Malformed JSON surfaces as an error but does not mutate state.
+	if err := p.OnConfig([]byte(`{bad json`)); err == nil {
+		t.Fatalf("OnConfig(bad) returned nil err, want decode error")
+	}
+}
+
+// TestPlugin_OnConfig_Nil_ResetsToDefaults covers the Host.ReEmitInitialize
+// reload path where a user has removed [plugins.treepane] entirely: the host
+// now invokes OnConfig(nil) and the plugin must reset its skip set to the
+// in-code defaults rather than retaining the previous (now stale) override.
+func TestPlugin_OnConfig_Nil_ResetsToDefaults(t *testing.T) {
+	root := buildFixture(t, map[string]string{
+		"node_modules/":         "",
+		"node_modules/pkg.json": "{}",
+		"src/":                  "",
+		"src/main.go":           "package main",
+	})
+	p, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Install an explicit override that skips nothing; confirm node_modules
+	// is visible after the rebuild.
+	if err := p.OnConfig([]byte(`{"skip_dirs":[]}`)); err != nil {
+		t.Fatalf("OnConfig(skip_dirs=[]): %v", err)
+	}
+	p.OnEvent(plugin.Initialize{RootPath: root})
+	out := p.Render(80, 20)
+	if !strings.Contains(out, "node_modules") {
+		t.Fatalf("pre-nil render missing node_modules:\n%s", out)
+	}
+
+	// Simulate the user deleting the [plugins.treepane] section entirely.
+	// The host's reload path now calls OnConfig(nil); the plugin must drop
+	// its previous override and restore the in-code defaults.
+	if err := p.OnConfig(nil); err != nil {
+		t.Fatalf("OnConfig(nil): %v", err)
+	}
+	p.OnEvent(plugin.Initialize{RootPath: root})
+	out = p.Render(80, 20)
+	if strings.Contains(out, "node_modules") {
+		t.Fatalf("after OnConfig(nil) node_modules is still visible — skip set did not reset:\n%s", out)
+	}
+	if !strings.Contains(out, "src") {
+		t.Fatalf("after OnConfig(nil) src/ is missing:\n%s", out)
+	}
+
+	// Zero-length raw (json.RawMessage{}) must take the same reset path.
+	if err := p.OnConfig([]byte(`{"skip_dirs":[]}`)); err != nil {
+		t.Fatalf("OnConfig(restore override): %v", err)
+	}
+	p.OnEvent(plugin.Initialize{RootPath: root})
+	if err := p.OnConfig(json.RawMessage{}); err != nil {
+		t.Fatalf("OnConfig(empty raw): %v", err)
+	}
+	p.OnEvent(plugin.Initialize{RootPath: root})
+	out = p.Render(80, 20)
+	if strings.Contains(out, "node_modules") {
+		t.Fatalf("after OnConfig(empty) node_modules is still visible:\n%s", out)
 	}
 }
 

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -51,6 +51,12 @@ type Initialize struct {
 	RootPath string `json:"rootPath"`
 	// Capabilities advertises host-side capabilities the plugin may rely on.
 	Capabilities []string `json:"capabilities"`
+	// Config is the plugin's own config sub-tree, encoded as raw JSON. It is
+	// nil when no host-side config lookup is installed or when the lookup
+	// returns nothing for this plugin's name. Plugins that prefer to receive
+	// config out of band can implement ConfigReceiver instead; both channels
+	// are kept in sync and carry the same bytes.
+	Config json.RawMessage `json:"config,omitempty"`
 }
 
 // Shutdown is emitted once before the plugin is torn down. Distinct from the
@@ -109,6 +115,13 @@ type Invalidate struct{}
 
 func (Invalidate) isEffect() {}
 
+// ReloadConfigRequest asks the editor to reload its configuration files and
+// re-emit per-plugin config via the host. Handled entirely on the editor
+// side; the plugin package has no knowledge of config file layout.
+type ReloadConfigRequest struct{}
+
+func (ReloadConfigRequest) isEffect() {}
+
 // Capability names a host-provided extension point a plugin may use.
 type Capability string
 
@@ -159,4 +172,24 @@ type Plugin interface {
 // before the Initialize event is dispatched.
 type HostAware interface {
 	SetHost(h *Host)
+}
+
+// ConfigReceiver is an optional extension implemented by in-process plugins
+// that want to receive their own config sub-tree out of band from the
+// Initialize event. The Host calls OnConfig immediately before dispatching
+// the Initialize event the first time, and again on every ReloadConfig call.
+// If the plugin also reads the Config field of Initialize it will see the
+// same bytes.
+//
+// OnConfig fires on every Initialize dispatch (initial boot and every
+// subsequent reload), regardless of whether a config sub-tree is present.
+// A nil raw argument means `[plugins.<name>]` is absent from the effective
+// config; plugins should treat this as a reset/defaults signal. The same
+// uniform contract applies to out-of-process plugins via plugsdk's
+// ConfigReceiver — both transports behave identically on the wire.
+// Implementations MUST treat a nil/empty raw as a reset rather than a
+// no-op, otherwise removing a config section will leave stale state
+// behind.
+type ConfigReceiver interface {
+	OnConfig(raw json.RawMessage) error
 }

--- a/plugin/extproc.go
+++ b/plugin/extproc.go
@@ -184,15 +184,7 @@ func (h *Host) spawn(m *Manifest) error {
 	initID := h.nextID()
 	respCh := make(chan *Response, 1)
 	ext.pending.Store(normalizeID(initID), respCh)
-	ext.enqueue(outFrame{
-		isNotif: false,
-		method:  "initialize",
-		id:      initID,
-		params: Initialize{
-			RootPath:     rootPath,
-			Capabilities: hostCapabilities,
-		},
-	})
+	ext.enqueue(h.buildInitializeFrame(m, rootPath, initID))
 
 	select {
 	case resp := <-respCh:
@@ -222,6 +214,24 @@ func (h *Host) spawn(m *Manifest) error {
 	go h.waitLoop(ext)
 
 	return nil
+}
+
+// buildInitializeFrame constructs the handshake Initialize request frame for
+// manifest m, injecting the plugin's configured sub-tree (if any) so the
+// spawn path stays symmetric with Emit — which also injects config via
+// Host.pluginConfigFor. Extracted as a named helper so it can be unit-tested
+// without spawning a real subprocess.
+func (h *Host) buildInitializeFrame(m *Manifest, rootPath string, id any) outFrame {
+	return outFrame{
+		isNotif: false,
+		method:  "initialize",
+		id:      id,
+		params: Initialize{
+			RootPath:     rootPath,
+			Capabilities: hostCapabilities,
+			Config:       h.pluginConfigFor(m.Name),
+		},
+	}
 }
 
 // manifestDir returns the on-disk directory for manifest m if it can be

--- a/plugin/host.go
+++ b/plugin/host.go
@@ -107,13 +107,14 @@ var hostCapabilities = []string{
 type Host struct {
 	registry *Registry
 
-	mu        sync.RWMutex
-	rootPath  string
-	started   bool
-	running   map[string]*extPlugin // name -> running external plugin
-	activated map[string]bool       // name -> has seen a matching activation
-	unhealthy map[string]bool       // in-proc plugins that panicked
-	inbound   chan PluginMsg
+	mu           sync.RWMutex
+	rootPath     string
+	started      bool
+	running      map[string]*extPlugin // name -> running external plugin
+	activated    map[string]bool       // name -> has seen a matching activation
+	unhealthy    map[string]bool       // in-proc plugins that panicked
+	inbound      chan PluginMsg
+	pluginConfig func(name string) json.RawMessage
 
 	// commands is *map[string]CommandRef, replaced via atomic.Value on each
 	// register/unregister so Commands() is lock-free for readers.
@@ -165,6 +166,29 @@ func (h *Host) Start(rootPath string) error {
 	return nil
 }
 
+// SetPluginConfig installs the per-plugin config lookup function. The host
+// calls it for every plugin that receives an Initialize event, and may call
+// it again from ReloadConfig (added in a later task). Passing nil clears
+// the lookup, returning the host to default "no config" behaviour. Safe to
+// call at any time; holds h.mu for the swap only.
+func (h *Host) SetPluginConfig(fn func(name string) json.RawMessage) {
+	h.mu.Lock()
+	h.pluginConfig = fn
+	h.mu.Unlock()
+}
+
+// pluginConfigFor returns the config bytes installed for the named plugin,
+// or nil when no lookup is installed or the lookup returns nothing.
+func (h *Host) pluginConfigFor(name string) json.RawMessage {
+	h.mu.RLock()
+	fn := h.pluginConfig
+	h.mu.RUnlock()
+	if fn == nil {
+		return nil
+	}
+	return fn(name)
+}
+
 // PostNotif enqueues a synthetic JSON-RPC notification on the host's
 // inbound channel, as if it had arrived from an out-of-process plugin.
 // Safe to call from any goroutine. Non-blocking: if the inbound channel
@@ -203,6 +227,7 @@ func (h *Host) PostNotif(plugin, method string, params any) error {
 // plugins' effects arrive later as PluginNotifMsg via Recv.
 func (h *Host) Emit(event any) []Effect {
 	method, params, actEv, hasActivation := describeEvent(event)
+	_, isInit := event.(Initialize)
 
 	var effects []Effect
 
@@ -212,7 +237,31 @@ func (h *Host) Emit(event any) []Effect {
 			continue
 		}
 		h.markActivated(p.Name())
-		ef := h.callOnEvent(p, event)
+
+		ev := event
+		if isInit {
+			raw := h.pluginConfigFor(p.Name())
+			// Deliver OnConfig first for plugins that opt into the out-of-band
+			// channel. OnConfig fires on every Initialize dispatch — even when
+			// raw is nil — so receivers see a uniform contract at both initial
+			// boot and reload. A nil raw signals "no [plugins.<name>] section
+			// is present; reset/keep defaults". See ConfigReceiver in api.go.
+			// Errors log but do not block Initialize; panics mark the plugin
+			// unhealthy and skip further events this session.
+			if cr, ok := p.(ConfigReceiver); ok {
+				if h.callOnConfig(p.Name(), cr, raw) {
+					// Unhealthy after panic; skip the Initialize event too.
+					continue
+				}
+			}
+			// Clone the Initialize value per-plugin so each sees its own
+			// config sub-tree.
+			init := event.(Initialize)
+			init.Config = raw
+			ev = init
+		}
+
+		ef := h.callOnEvent(p, ev)
 		effects = append(effects, ef...)
 	}
 
@@ -236,10 +285,39 @@ func (h *Host) Emit(event any) []Effect {
 			// Event has no wire representation (unknown type). Skip silently.
 			continue
 		}
-		ext.sendEvent(method, params, event)
+
+		// Per-plugin params clone for Initialize so each out-of-proc plugin
+		// receives its own config sub-tree. Keep params/raw in sync so the
+		// coalescing path sees a consistent pair.
+		sendParams := params
+		sendRaw := event
+		if isInit {
+			init := event.(Initialize)
+			init.Config = h.pluginConfigFor(m.Name)
+			sendParams = init
+			sendRaw = init
+		}
+		ext.sendEvent(method, sendParams, sendRaw)
 	}
 
 	return effects
+}
+
+// callOnConfig invokes cr.OnConfig with panic recovery. Returns true when a
+// panic marked the plugin unhealthy. OnConfig-returned errors are logged to
+// stderr but do NOT mark the plugin unhealthy, letting Initialize still land.
+func (h *Host) callOnConfig(name string, cr ConfigReceiver, raw json.RawMessage) (unhealthy bool) {
+	defer func() {
+		// Panic boundary: a misbehaving OnConfig must not take down the host.
+		if r := recover(); r != nil {
+			h.markUnhealthy(name, fmt.Errorf("panic in OnConfig: %v", r))
+			unhealthy = true
+		}
+	}()
+	if err := cr.OnConfig(raw); err != nil {
+		fmt.Fprintf(os.Stderr, "plugin: %s: OnConfig: %v\n", name, err)
+	}
+	return false
 }
 
 // isInProcName reports whether the given name is an in-proc plugin. Avoids
@@ -524,6 +602,88 @@ func (h *Host) ExecuteCommand(id string, args json.RawMessage) CommandResult {
 	return CommandResult{Sync: &CommandSyncResult{
 		Err: fmt.Errorf("plugin: owner %q of command %q is not registered", ref.Plugin, id),
 	}}
+}
+
+// ReEmitInitialize re-delivers the Initialize event to every plugin that
+// has already been activated, so they can pick up fresh per-plugin config
+// after a SetPluginConfig swap. In-proc plugins receive OnConfig + the
+// Initialize event via OnEvent; out-of-proc plugins receive a fresh
+// initialize JSON-RPC notification (NOT a new spawn handshake — they are
+// already running). New plugins never seen before are NOT started here.
+//
+// Must be called on the Bubble Tea UI goroutine to preserve the
+// "in-proc OnEvent runs on UI goroutine" invariant.
+func (h *Host) ReEmitInitialize() {
+	// Snapshot the activated + rootPath under RLock so the subsequent
+	// dispatch loop doesn't need to re-acquire. Also snapshot the unhealthy
+	// set — unhealthy plugins must be skipped so we don't revive them.
+	h.mu.RLock()
+	rootPath := h.rootPath
+	activated := make(map[string]bool, len(h.activated))
+	for k, v := range h.activated {
+		activated[k] = v
+	}
+	unhealthy := make(map[string]bool, len(h.unhealthy))
+	for k, v := range h.unhealthy {
+		unhealthy[k] = v
+	}
+	running := make(map[string]*extPlugin, len(h.running))
+	for k, v := range h.running {
+		running[k] = v
+	}
+	h.mu.RUnlock()
+
+	// In-proc dispatch: every in-proc plugin that has been activated gets a
+	// fresh OnConfig (if implemented) then a fresh Initialize OnEvent.
+	//
+	// OnConfig fires unconditionally — even when raw is nil — matching the
+	// initial Emit path's behaviour. A nil raw signals "the config section
+	// is absent now; reset any config-derived state to defaults". Without
+	// this, a user who deletes a [plugins.<name>] section and reloads would
+	// still observe stale config-derived state inside the plugin. See
+	// ConfigReceiver in plugin/api.go for the nil-raw contract.
+	for _, p := range h.registry.InProc() {
+		name := p.Name()
+		if !activated[name] || unhealthy[name] {
+			continue
+		}
+		raw := h.pluginConfigFor(name)
+		if cr, ok := p.(ConfigReceiver); ok {
+			if h.callOnConfig(name, cr, raw) {
+				// Panic marked the plugin unhealthy; skip the event dispatch.
+				continue
+			}
+		}
+		init := Initialize{
+			RootPath:     rootPath,
+			Capabilities: hostCapabilities,
+			Config:       raw,
+		}
+		_ = h.callOnEvent(p, init)
+	}
+
+	// Out-of-proc dispatch: only already-running plugins. We deliberately
+	// do NOT call ensureSpawned — this is a re-emit, not a cold start.
+	for _, m := range h.registry.Manifests() {
+		name := m.Name
+		// An in-proc plugin with the same name wins (mirrors Emit).
+		if h.isInProcName(name) {
+			continue
+		}
+		if unhealthy[name] {
+			continue
+		}
+		ext, ok := running[name]
+		if !ok {
+			continue
+		}
+		init := Initialize{
+			RootPath:     rootPath,
+			Capabilities: hostCapabilities,
+			Config:       h.pluginConfigFor(name),
+		}
+		ext.sendEvent("initialize", init, init)
+	}
 }
 
 // Recv returns a tea.Cmd that blocks on the aggregated inbound channel and

--- a/plugin/host_test.go
+++ b/plugin/host_test.go
@@ -284,6 +284,413 @@ func TestPostNotifDropsOnFullInbound(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
+// Per-plugin config (ConfigReceiver / Initialize.Config) exercises.
+
+// configReceiverPlugin is a minimal in-proc plugin that records every
+// OnConfig call. Declared locally so the default fakeInProcPlugin stays
+// ignorant of the optional interface.
+type configReceiverPlugin struct {
+	fakeInProcPlugin
+	mu        sync.Mutex
+	received  []json.RawMessage
+	returnErr error
+}
+
+func (p *configReceiverPlugin) OnConfig(raw json.RawMessage) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Copy — callers are free to retain the slice.
+	cp := make(json.RawMessage, len(raw))
+	copy(cp, raw)
+	p.received = append(p.received, cp)
+	return p.returnErr
+}
+
+func (p *configReceiverPlugin) calls() []json.RawMessage {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]json.RawMessage, len(p.received))
+	copy(out, p.received)
+	return out
+}
+
+// panickyConfigReceiver panics on OnConfig; used to verify the host's panic
+// boundary around the optional hook.
+type panickyConfigReceiver struct {
+	fakeInProcPlugin
+}
+
+func (p *panickyConfigReceiver) OnConfig(raw json.RawMessage) error {
+	panic("boom-in-onconfig")
+}
+
+func TestHost_InProc_ConfigReceiver_ReceivesOwnSubtree(t *testing.T) {
+	want := json.RawMessage(`{"a":1}`)
+	p := &configReceiverPlugin{
+		fakeInProcPlugin: fakeInProcPlugin{name: "cfg", acts: []string{"onStart"}},
+	}
+	other := &fakeInProcPlugin{name: "other", acts: []string{"onStart"}}
+	h := newHostWithPlugins(p, other)
+	h.SetPluginConfig(func(name string) json.RawMessage {
+		if name == "cfg" {
+			return want
+		}
+		return nil
+	})
+
+	h.Emit(Initialize{RootPath: "/root"})
+
+	calls := p.calls()
+	if len(calls) != 1 {
+		t.Fatalf("OnConfig calls = %d, want 1", len(calls))
+	}
+	if string(calls[0]) != string(want) {
+		t.Fatalf("OnConfig raw = %s, want %s", calls[0], want)
+	}
+}
+
+func TestHost_InProc_InitializeEvent_CarriesConfig(t *testing.T) {
+	want := json.RawMessage(`{"a":1}`)
+	p := &fakeInProcPlugin{name: "plain", acts: []string{"onStart"}}
+	h := newHostWithPlugins(p)
+	h.SetPluginConfig(func(name string) json.RawMessage {
+		if name == "plain" {
+			return want
+		}
+		return nil
+	})
+
+	h.Emit(Initialize{RootPath: "/root"})
+
+	if len(p.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(p.events))
+	}
+	init, ok := p.events[0].(Initialize)
+	if !ok {
+		t.Fatalf("event type = %T, want Initialize", p.events[0])
+	}
+	if string(init.Config) != string(want) {
+		t.Fatalf("Initialize.Config = %s, want %s", init.Config, want)
+	}
+	if init.RootPath != "/root" {
+		t.Fatalf("Initialize.RootPath = %q, want /root", init.RootPath)
+	}
+}
+
+func TestHost_InProc_NoLookup_NoConfig(t *testing.T) {
+	recv := &configReceiverPlugin{
+		fakeInProcPlugin: fakeInProcPlugin{name: "cfg", acts: []string{"onStart"}},
+	}
+	h := newHostWithPlugins(recv)
+	// No SetPluginConfig call at all.
+
+	h.Emit(Initialize{RootPath: "/root"})
+
+	// Unified contract: OnConfig fires on every Initialize dispatch, even
+	// when no lookup is installed. Plugins that implement ConfigReceiver
+	// see OnConfig(nil) as a signal to keep/reset defaults.
+	calls := recv.calls()
+	if len(calls) != 1 {
+		t.Fatalf("OnConfig calls = %d, want 1 (nil raw when no lookup)", len(calls))
+	}
+	if len(calls[0]) != 0 {
+		t.Fatalf("OnConfig raw = %s, want nil/empty without lookup", calls[0])
+	}
+	if len(recv.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(recv.events))
+	}
+	init, ok := recv.events[0].(Initialize)
+	if !ok {
+		t.Fatalf("event type = %T, want Initialize", recv.events[0])
+	}
+	if init.Config != nil {
+		t.Fatalf("Initialize.Config = %s, want nil without lookup", init.Config)
+	}
+}
+
+func TestHost_InProc_OnConfigPanics_MarksUnhealthy(t *testing.T) {
+	p := &panickyConfigReceiver{
+		fakeInProcPlugin: fakeInProcPlugin{name: "panicky", acts: []string{"onStart"}},
+	}
+	h := newHostWithPlugins(p)
+	h.SetPluginConfig(func(name string) json.RawMessage {
+		return json.RawMessage(`{"x":true}`)
+	})
+
+	h.Emit(Initialize{RootPath: "/root"})
+
+	// Initialize must NOT have been delivered (panic skipped OnEvent).
+	if len(p.events) != 0 {
+		t.Fatalf("plugin got events after OnConfig panic: %+v", p.events)
+	}
+	h.mu.RLock()
+	unhealthy := h.unhealthy[p.Name()]
+	h.mu.RUnlock()
+	if !unhealthy {
+		t.Fatalf("plugin not marked unhealthy after OnConfig panic")
+	}
+
+	// Subsequent emits must not deliver either.
+	h.Emit(DidOpen{Path: "/a.go", Lang: "go"})
+	if len(p.events) != 0 {
+		t.Fatalf("unhealthy plugin received follow-up events: %+v", p.events)
+	}
+}
+
+// TestHost_OutOfProc_SpawnHandshake_CarriesConfig asserts the spawn-path
+// Initialize frame carries the plugin's configured sub-tree, symmetric with
+// the Emit-path injection covered above. Spawning a real subprocess just to
+// read the handshake would require a separate test binary and is brittle, so
+// instead we exercise the pure buildInitializeFrame helper that spawn now
+// delegates to — that helper is the single point that pulls config from the
+// host and embeds it in the outbound Initialize.
+func TestHost_OutOfProc_SpawnHandshake_CarriesConfig(t *testing.T) {
+	want := json.RawMessage(`{"channel":"dev"}`)
+	reg := NewRegistry()
+	m := &Manifest{
+		Name:       "ext",
+		Version:    "0.0.1",
+		Cmd:        []string{"ignored"},
+		Activation: []string{"onLanguage:go"},
+	}
+	reg.manifests = append(reg.manifests, m)
+	h := NewHost(reg)
+	if err := h.Start(""); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	h.SetPluginConfig(func(name string) json.RawMessage {
+		if name == "ext" {
+			return want
+		}
+		return nil
+	})
+
+	frame := h.buildInitializeFrame(m, "/root", int64(1))
+	if frame.method != "initialize" {
+		t.Fatalf("frame.method = %q, want initialize", frame.method)
+	}
+	if frame.isNotif {
+		t.Fatalf("frame.isNotif = true, want false (request)")
+	}
+	init, ok := frame.params.(Initialize)
+	if !ok {
+		t.Fatalf("frame.params type = %T, want Initialize", frame.params)
+	}
+	if string(init.Config) != string(want) {
+		t.Fatalf("Initialize.Config = %s, want %s", init.Config, want)
+	}
+	if init.RootPath != "/root" {
+		t.Fatalf("Initialize.RootPath = %q, want /root", init.RootPath)
+	}
+	if len(init.Capabilities) == 0 {
+		t.Fatalf("Initialize.Capabilities empty, want host capabilities")
+	}
+}
+
+// TestHost_ReEmitInitialize_DeliversToActivatedOnly asserts that
+// ReEmitInitialize re-fires OnConfig + OnEvent(Initialize) for in-proc
+// plugins that have already been activated and skips those that have not.
+// The dormant plugin shares the same activation, so the scope test is
+// "did Initialize dispatch previously reach this plugin", not "does the
+// activation match".
+func TestHost_ReEmitInitialize_DeliversToActivatedOnly(t *testing.T) {
+	// Two ConfigReceiver stubs. Only the first activates (onStart). The
+	// second activates on a language we never emit, so Initialize never
+	// lands on it — it stays dormant until ReEmit runs.
+	active := &configReceiverPlugin{
+		fakeInProcPlugin: fakeInProcPlugin{name: "active", acts: []string{"onStart"}},
+	}
+	dormant := &configReceiverPlugin{
+		fakeInProcPlugin: fakeInProcPlugin{name: "dormant", acts: []string{"onLanguage:py"}},
+	}
+	h := newHostWithPlugins(active, dormant)
+
+	// First config tree.
+	first := json.RawMessage(`{"k":1}`)
+	h.SetPluginConfig(func(name string) json.RawMessage {
+		if name == "active" {
+			return first
+		}
+		return nil
+	})
+	h.Emit(Initialize{RootPath: "/r"})
+
+	// Sanity: only active saw OnConfig once.
+	if n := len(active.calls()); n != 1 {
+		t.Fatalf("pre: active OnConfig calls = %d, want 1", n)
+	}
+	if n := len(dormant.calls()); n != 0 {
+		t.Fatalf("pre: dormant OnConfig calls = %d, want 0", n)
+	}
+	if n := len(active.events); n != 1 {
+		t.Fatalf("pre: active events = %d, want 1", n)
+	}
+	if n := len(dormant.events); n != 0 {
+		t.Fatalf("pre: dormant events = %d, want 0", n)
+	}
+
+	// Swap the config and re-emit.
+	second := json.RawMessage(`{"k":2}`)
+	h.SetPluginConfig(func(name string) json.RawMessage {
+		if name == "active" {
+			return second
+		}
+		return nil
+	})
+	h.ReEmitInitialize()
+
+	// Active: one more OnConfig with the new bytes, one more Initialize.
+	activeCalls := active.calls()
+	if len(activeCalls) != 2 {
+		t.Fatalf("post: active OnConfig calls = %d, want 2", len(activeCalls))
+	}
+	if string(activeCalls[1]) != string(second) {
+		t.Fatalf("post: active second OnConfig = %s, want %s", activeCalls[1], second)
+	}
+	if len(active.events) != 2 {
+		t.Fatalf("post: active events = %d, want 2", len(active.events))
+	}
+	init, ok := active.events[1].(Initialize)
+	if !ok {
+		t.Fatalf("post: active second event = %T, want Initialize", active.events[1])
+	}
+	if string(init.Config) != string(second) {
+		t.Fatalf("post: Initialize.Config = %s, want %s", init.Config, second)
+	}
+
+	// Dormant: must stay untouched.
+	if n := len(dormant.calls()); n != 0 {
+		t.Fatalf("post: dormant OnConfig calls = %d, want 0", n)
+	}
+	if n := len(dormant.events); n != 0 {
+		t.Fatalf("post: dormant events = %d, want 0", n)
+	}
+}
+
+// TestHost_ReEmitInitialize_CallsOnConfigWithNilWhenLookupReturnsNil
+// exercises the host-layer fix for the "treepane reload leaves stale
+// skip_dirs when config is removed" bug. On reload (ReEmitInitialize), the
+// host MUST call OnConfig unconditionally — even when the installed lookup
+// returns nil for the plugin's name — so ConfigReceiver implementations can
+// reset config-derived state. The initial Emit path keeps the "OnConfig
+// fires only when raw != nil" guard; only the reload dispatch changes.
+func TestHost_ReEmitInitialize_CallsOnConfigWithNilWhenLookupReturnsNil(t *testing.T) {
+	stub := &configReceiverPlugin{
+		fakeInProcPlugin: fakeInProcPlugin{name: "stub", acts: []string{"onStart"}},
+	}
+	h := newHostWithPlugins(stub)
+
+	// First activation with a real config sub-tree so the plugin is
+	// recorded as activated and OnConfig lands with the expected bytes.
+	first := json.RawMessage(`{"x":1}`)
+	h.SetPluginConfig(func(name string) json.RawMessage {
+		if name == "stub" {
+			return first
+		}
+		return nil
+	})
+	h.Emit(Initialize{RootPath: "/r"})
+
+	calls := stub.calls()
+	if len(calls) != 1 {
+		t.Fatalf("pre: OnConfig calls = %d, want 1", len(calls))
+	}
+	if string(calls[0]) != string(first) {
+		t.Fatalf("pre: OnConfig[0] = %s, want %s", calls[0], first)
+	}
+
+	// Simulate the user removing [plugins.stub] from config: the lookup
+	// now returns nil for every name.
+	h.SetPluginConfig(func(name string) json.RawMessage {
+		return nil
+	})
+
+	// Reload must deliver OnConfig(nil) despite raw being nil, so the
+	// plugin can reset config-derived state back to defaults.
+	h.ReEmitInitialize()
+
+	calls = stub.calls()
+	if len(calls) < 2 {
+		t.Fatalf("post: OnConfig calls = %d, want >= 2", len(calls))
+	}
+	// Expect to observe at least one nil OnConfig after the lookup swap.
+	sawNil := false
+	for _, c := range calls[1:] {
+		if len(c) == 0 {
+			sawNil = true
+			break
+		}
+	}
+	if !sawNil {
+		t.Fatalf("post: no OnConfig(nil) observed after reload; calls = %v", calls)
+	}
+
+	// The Initialize event itself must still land, carrying nil Config.
+	if len(stub.events) < 2 {
+		t.Fatalf("post: events = %d, want >= 2 (Initialize re-emit)", len(stub.events))
+	}
+	init, ok := stub.events[1].(Initialize)
+	if !ok {
+		t.Fatalf("post: second event = %T, want Initialize", stub.events[1])
+	}
+	if init.Config != nil {
+		t.Fatalf("post: Initialize.Config = %s, want nil after lookup removal", init.Config)
+	}
+}
+
+// TestHost_Emit_InitialBoot_CallsOnConfigEvenWhenRawNil asserts the unified
+// ConfigReceiver contract on the initial Emit path: OnConfig fires on every
+// Initialize dispatch, even when the lookup returns nil for the plugin's
+// name. A nil raw signals "no [plugins.<name>] section is present; reset to
+// defaults". This matches the reload path (ReEmitInitialize) and the
+// out-of-process SDK dispatch semantics, so receivers can't be caught out
+// by split-semantics between transports or call sites.
+func TestHost_Emit_InitialBoot_CallsOnConfigEvenWhenRawNil(t *testing.T) {
+	stub := &configReceiverPlugin{
+		fakeInProcPlugin: fakeInProcPlugin{name: "stub", acts: []string{"onStart"}},
+	}
+	h := newHostWithPlugins(stub)
+	// Lookup installed, but returns nil for every name.
+	h.SetPluginConfig(func(name string) json.RawMessage {
+		return nil
+	})
+	h.Emit(Initialize{RootPath: "/r"})
+
+	calls := stub.calls()
+	if len(calls) != 1 {
+		t.Fatalf("OnConfig calls = %d, want 1 even when raw is nil", len(calls))
+	}
+	if len(calls[0]) != 0 {
+		t.Fatalf("OnConfig raw = %s, want nil/empty", calls[0])
+	}
+	if len(stub.events) != 1 {
+		t.Fatalf("Initialize not delivered: events = %d, want 1", len(stub.events))
+	}
+}
+
+// TestHost_OutOfProc_SpawnHandshake_NoConfigIsOmitted asserts the helper
+// emits a nil Config when no lookup is installed, so the wire JSON omits
+// the field (omitempty) and plugins without config see no surprise value.
+func TestHost_OutOfProc_SpawnHandshake_NoConfigIsOmitted(t *testing.T) {
+	reg := NewRegistry()
+	m := &Manifest{Name: "ext", Version: "0.0.1", Cmd: []string{"ignored"}}
+	reg.manifests = append(reg.manifests, m)
+	h := NewHost(reg)
+	if err := h.Start(""); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	frame := h.buildInitializeFrame(m, "/root", int64(1))
+	init, ok := frame.params.(Initialize)
+	if !ok {
+		t.Fatalf("frame.params type = %T, want Initialize", frame.params)
+	}
+	if init.Config != nil {
+		t.Fatalf("Initialize.Config = %s, want nil without a lookup", init.Config)
+	}
+}
+
+// -----------------------------------------------------------------------------
 // Out-of-proc host exercises.
 
 func TestHost_SpawnAndInitialize(t *testing.T) {

--- a/sdk/plugsdk/plugsdk.go
+++ b/sdk/plugsdk/plugsdk.go
@@ -39,6 +39,20 @@ type ClientReceiver interface {
 	SetClient(*Client)
 }
 
+// ConfigReceiver is an optional extension: plugins implementing it receive
+// their config sub-tree as a JSON RawMessage. OnConfig fires on every
+// Initialize dispatch (once before OnInitialize on spawn, and again on every
+// host reload), regardless of whether a config sub-tree is present. A nil
+// raw argument means `[plugins.<name>]` is absent from the effective config;
+// plugins should treat this as a reset/defaults signal. This mirrors the
+// in-process plugin.ConfigReceiver contract — the host invokes both with the
+// same semantics. Plugins that only need config at startup can also read it
+// from the Initialize frame (the Config field), whichever is more
+// convenient.
+type ConfigReceiver interface {
+	OnConfig(raw json.RawMessage) error
+}
+
 // Base is a zero-value Plugin with no-op defaults. Embed it to avoid
 // implementing methods you do not care about. Base also satisfies
 // ClientReceiver: call Base.Client() from your methods to reach the host.
@@ -56,6 +70,9 @@ func (b *Base) Client() *Client { return b.client }
 
 // OnInitialize is the no-op default.
 func (b *Base) OnInitialize(root string, capabilities []string) error { return nil }
+
+// OnConfig is the no-op default; plugins that care about config override it.
+func (Base) OnConfig(raw json.RawMessage) error { return nil }
 
 // OnShutdown is the no-op default.
 func (b *Base) OnShutdown() error { return nil }
@@ -316,6 +333,18 @@ func dispatch(p Plugin, codec *plugin.Codec, method string, id any, params json.
 		var ev plugin.Initialize
 		if err := json.Unmarshal(params, &ev); err != nil {
 			return writeInvalidParams(codec, id, err)
+		}
+		// OnConfig fires before OnInitialize so receivers see config first.
+		// OnConfig errors are logged but non-fatal, matching the in-proc
+		// host behaviour in plugin.Host.callOnConfig. OnConfig fires on every
+		// Initialize dispatch — even when ev.Config is nil — so plugins see a
+		// uniform contract across initial spawn and reload. A nil raw signals
+		// "no [plugins.<name>] section is present; reset to defaults". See
+		// ConfigReceiver above.
+		if cr, ok := p.(ConfigReceiver); ok {
+			if cfgErr := cr.OnConfig(ev.Config); cfgErr != nil {
+				fmt.Fprintf(os.Stderr, "plugsdk: OnConfig: %v\n", cfgErr)
+			}
 		}
 		initErr := p.OnInitialize(ev.RootPath, ev.Capabilities)
 		if id == nil {

--- a/sdk/plugsdk/plugsdk_test.go
+++ b/sdk/plugsdk/plugsdk_test.go
@@ -890,6 +890,151 @@ func (p *bufferEditPlugin) OnExecuteCommand(id string, args json.RawMessage) (an
 	return nil, nil
 }
 
+// configRecordingPlugin implements ConfigReceiver and records every OnConfig
+// invocation (raw bytes + ordering vs. OnInitialize) so tests can assert the
+// SDK routes config through the optional interface correctly.
+type configRecordingPlugin struct {
+	Base
+	mu            sync.Mutex
+	configs       []json.RawMessage
+	initsAfterCfg int // incremented on OnInitialize only when configs non-empty at call time
+	inits         int
+}
+
+func (p *configRecordingPlugin) OnConfig(raw json.RawMessage) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	cp := make(json.RawMessage, len(raw))
+	copy(cp, raw)
+	p.configs = append(p.configs, cp)
+	return nil
+}
+
+func (p *configRecordingPlugin) OnInitialize(root string, caps []string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.inits++
+	if len(p.configs) > 0 {
+		p.initsAfterCfg++
+	}
+	return nil
+}
+
+// TestSDK_Initialize_RoutesConfigToReceiver asserts an initialize frame
+// carrying a Config sub-tree invokes OnConfig with the exact bytes before
+// OnInitialize fires.
+func TestSDK_Initialize_RoutesConfigToReceiver(t *testing.T) {
+	pluginSide, host, cleanup := pipePair()
+	defer cleanup()
+
+	p := &configRecordingPlugin{}
+	done := startRun(p, pluginSide)
+
+	want := json.RawMessage(`{"a":1}`)
+	if err := host.WriteRequest("initialize", 1, plugin.Initialize{
+		RootPath:     "/r",
+		Capabilities: []string{"commands"},
+		Config:       want,
+	}); err != nil {
+		t.Fatalf("write init: %v", err)
+	}
+	_, _, _, isResp, resp := readOne(t, host)
+	if !isResp || resp == nil || resp.Error != nil {
+		t.Fatalf("expected success response, got isResp=%v resp=%+v", isResp, resp)
+	}
+
+	p.mu.Lock()
+	if got := len(p.configs); got != 1 {
+		p.mu.Unlock()
+		t.Fatalf("OnConfig calls = %d, want 1", got)
+	}
+	if string(p.configs[0]) != string(want) {
+		p.mu.Unlock()
+		t.Fatalf("OnConfig raw = %s, want %s", p.configs[0], want)
+	}
+	if p.inits != 1 {
+		p.mu.Unlock()
+		t.Fatalf("OnInitialize calls = %d, want 1", p.inits)
+	}
+	if p.initsAfterCfg != 1 {
+		p.mu.Unlock()
+		t.Fatalf("OnInitialize fired before OnConfig (initsAfterCfg=%d)", p.initsAfterCfg)
+	}
+	p.mu.Unlock()
+
+	if err := host.WriteNotification("shutdown", struct{}{}); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+	if err := waitDone(t, done, 2*time.Second); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+}
+
+// TestSDK_Initialize_NoConfig_CallsOnConfigWithNil asserts the unified
+// ConfigReceiver contract: an initialize frame without a Config field still
+// invokes OnConfig with a nil raw argument, signalling "no config section
+// is present; reset to defaults". This matches the in-process host contract
+// in plugin.ConfigReceiver — both transports have uniform semantics so
+// plugin authors don't need to special-case their transport.
+func TestSDK_Initialize_NoConfig_CallsOnConfigWithNil(t *testing.T) {
+	pluginSide, host, cleanup := pipePair()
+	defer cleanup()
+
+	p := &configRecordingPlugin{}
+	done := startRun(p, pluginSide)
+
+	if err := host.WriteRequest("initialize", 1, plugin.Initialize{
+		RootPath:     "/r",
+		Capabilities: []string{"commands"},
+	}); err != nil {
+		t.Fatalf("write init: %v", err)
+	}
+	_, _, _, isResp, resp := readOne(t, host)
+	if !isResp || resp == nil || resp.Error != nil {
+		t.Fatalf("expected success response, got isResp=%v resp=%+v", isResp, resp)
+	}
+
+	p.mu.Lock()
+	if got := len(p.configs); got != 1 {
+		p.mu.Unlock()
+		t.Fatalf("OnConfig calls = %d, want 1 (with nil raw when no Config field)", got)
+	}
+	if got := len(p.configs[0]); got != 0 {
+		raw := p.configs[0]
+		p.mu.Unlock()
+		t.Fatalf("OnConfig raw = %s, want nil/empty when initialize frame has no Config", raw)
+	}
+	if p.inits != 1 {
+		p.mu.Unlock()
+		t.Fatalf("OnInitialize calls = %d, want 1", p.inits)
+	}
+	// OnConfig must still fire before OnInitialize.
+	if p.initsAfterCfg != 1 {
+		p.mu.Unlock()
+		t.Fatalf("OnInitialize fired before OnConfig (initsAfterCfg=%d)", p.initsAfterCfg)
+	}
+	p.mu.Unlock()
+
+	if err := host.WriteNotification("shutdown", struct{}{}); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+	if err := waitDone(t, done, 2*time.Second); err != nil {
+		t.Fatalf("RunWith: %v", err)
+	}
+}
+
+// TestSDK_Base_OnConfig_IsNoOp asserts the default Base.OnConfig is a
+// harmless no-op for embedders that don't care about config.
+func TestSDK_Base_OnConfig_IsNoOp(t *testing.T) {
+	var b Base
+	if err := b.OnConfig(nil); err != nil {
+		t.Fatalf("Base.OnConfig(nil) = %v, want nil", err)
+	}
+	if err := b.OnConfig([]byte("{}")); err != nil {
+		t.Fatalf("Base.OnConfig({}) = %v, want nil", err)
+	}
+}
+
 // TestToUint64Accepts covers each branch of the id-normalizer the SDK uses
 // when routing responses.
 func TestToUint64Accepts(t *testing.T) {


### PR DESCRIPTION
## Summary
- Two-tier TOML config: `~/.config/nistru/config.toml` (user) + `<root>/.nistru/config.toml` (project), merged with `NISTRU_*` env overrides (precedence: defaults → user → project → env).
- Plugin config distributed via extended `Initialize` handshake and a new `ConfigReceiver.OnConfig(raw)` hook — unified across in-proc and out-of-proc transports. `nil` raw means "section absent; reset to defaults."
- Explicit reload via palette: `nistru.settings.{openUser,openProject,reload,showResolved}`. No fsnotify.
- Editor knobs (relative numbers, keymap, debounces, max file size) rebuild on reload when changed.
- First-party plugins (`autoupdate`, `treepane`) migrated to `ConfigReceiver`; `autoupdate` stops its checker on reload to avoid goroutine leaks.

## Test plan
- [x] `make ci` — green, coverage 74.9%
- [x] `make e2e` — goldens byte-identical
- [x] `make race` — no races in plugin host/extproc paths
- [ ] Manual: edit `~/.config/nistru/config.toml`, run `nistru.settings.reload`, confirm UI updates
- [ ] Manual: set `NISTRU_AUTOUPDATE_CHANNEL=dev`, confirm env beats file
- [ ] Manual: remove `[plugins.treepane]` section, reload, confirm `skip_dirs` reverts to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)