### PR TITLE
ci: dedupe push/pull_request triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Scope the \`push\` trigger to \`master\` so in-repo PR branches stop running CI twice (once on push, once on pull_request) against the same SHA — seen on #8.
- Add a ref-scoped \`concurrency\` group with \`cancel-in-progress: true\` so rapid re-pushes to the same ref cancel the older run instead of queuing.

## Test plan
- [ ] Open/push to this PR and confirm a single check run appears (pull_request), not two.
- [ ] After merge, confirm \`master\` gets its own post-merge CI run (push to master).
- [ ] Push a follow-up commit to this branch and confirm the older run is cancelled, not duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)