### PR TITLE
ci: add goreleaser release pipeline with homebrew tap + nfpm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          cache: true
+
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 cmd/nistru/nistru
 /examples/plugins/hello-world/hello-world
 /examples/plugins/gofmt/gofmt-plugin
+# Goreleaser build output
+/dist/
 *.swp
 .DS_Store
 coverage.out

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,85 @@
+version: 2
+
+project_name: nistru
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: nistru
+    main: ./cmd/nistru
+    binary: nistru
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w -X main.Version={{.Version}}
+
+archives:
+  - id: nistru
+    ids:
+      - nistru
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: "checksums.txt"
+
+release:
+  prerelease: auto
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+
+brews:
+  - name: nistru
+    ids:
+      - nistru
+    repository:
+      owner: savimcio
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/savimcio/nistru"
+    description: "A minimal terminal text editor with a file-tree sidebar, modal vim-style editing, micro-inspired Ctrl shortcuts, and a plugin system for formatters, linters, and custom panes."
+    license: "MIT"
+    skip_upload: auto
+    test: |
+      system "#{bin}/nistru", "--version"
+
+nfpms:
+  - id: nistru
+    package_name: nistru
+    ids:
+      - nistru
+    vendor: savimcio
+    homepage: "https://github.com/savimcio/nistru"
+    maintainer: "savimcio <noreply@users.noreply.github.com>"
+    description: "A minimal terminal text editor with a file-tree sidebar, modal vim-style editing, micro-inspired Ctrl shortcuts, and a plugin system for formatters, linters, and custom panes."
+    license: "MIT"
+    formats:
+      - deb
+      - rpm

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-short race cover lint fuzz e2e ci fmt clean examples-test build
+.PHONY: test test-short race cover lint fuzz e2e ci fmt clean examples-test build release-check release-snapshot
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 
@@ -51,3 +51,9 @@ fmt:
 clean:
 	rm -f coverage.out coverage.html
 	rm -rf bin
+
+release-check:
+	goreleaser check
+
+release-snapshot:
+	goreleaser release --snapshot --clean --skip=publish


### PR DESCRIPTION
## Summary

- Tag-triggered GitHub Actions workflow runs goreleaser v2 on `v*` tags
- Produces `nistru_<version>_<os>_<arch>.{tar.gz,zip}` archives plus `checksums.txt`, matching what `internal/plugins/autoupdate/` parses (`asset.go:22-28`, `install.go:413`)
- Publishes a Homebrew formula to `savimcio/homebrew-tap` via a dedicated `HOMEBREW_TAP_TOKEN` secret — fine-grained PAT scoped to the tap repo only (least-privilege vs. reusing the release token)
- Emits `deb` + `rpm` via nfpm for distro package managers
- `release.prerelease: auto` — semver pre-release tags (e.g. `v0.2.0-rc.1`) auto-flip the GitHub prerelease bit, feeding the auto-update plugin's dev channel (`github.go:150-158`); stable tags feed the release channel

## Why these exact values are load-bearing

- `checksum.name_template: "checksums.txt"` — pinned literally because the plugin hard-matches this basename (`asset.go:16`) and refuses to install without it (`install.go:413`). Goreleaser v2's default has drifted across versions.
- `builds.binary: nistru` — the extractor looks for basename `nistru` / `nistru.exe` (`install.go:687`).
- `ldflags: -X main.Version={{.Version}}` — stamps the `main.Version` var the plugin reads via `SetVersion`.
- Archive `name_template` — equals goreleaser's default, which is exactly the first pattern `AssetMatch` tries.

## Test plan

- [x] `make release-check` passes (v2.15.4)
- [x] `make release-snapshot` produces 5 archives + `checksums.txt` + 4 nfpm packages in `~17s`
- [x] `internal/plugins/autoupdate.AssetMatch` resolves all 5 (goos, goarch) pairs against real-tag artifact names
- [x] Linux tarball contains `nistru` at root (ELF 64-bit x86-64, stripped); Windows zip contains `nistru.exe`
- [x] `make ci` green locally (coverage 74.9%)
- [ ] CI green on this PR
- [ ] After merge: push `v0.2.0-rc.1` tag → verify GH release created with `prerelease: true`, `checksums.txt` + archives present, and the auto-update plugin's dev channel picks it up end-to-end

## Out of scope (follow-ups)

- Cosign keyless signing / SLSA provenance / SBOM — nice defense-in-depth, but the plugin doesn't verify signatures today
- winget / scoop manifests for Windows
- Docker image publish