### PR TITLE
fix(autoupdate): accept SemVer prerelease versions in asset names

### DIFF
--- a/internal/plugins/autoupdate/asset.go
+++ b/internal/plugins/autoupdate/asset.go
@@ -20,7 +20,7 @@ const checksumsAssetName = "checksums.txt"
 //
 // Supported name patterns (tried in order, case-insensitive):
 //
-//	nistru_<version>_<goos>_<goarch>.tar.gz
+//	nistru_<version>_<goos>_<goarch>.tar.gz    (version may be SemVer with prerelease, e.g. "0.2.0-rc.1")
 //	nistru_<goos>_<goarch>.tar.gz
 //	nistru-<goos>-<goarch>.tar.gz
 //	nistru_<version>_<goos>_<goarch>.zip
@@ -66,7 +66,11 @@ func AssetMatch(rel Release, goos, goarch string) (Asset, Asset, error) {
 //
 // The allowed extensions are ".tar.gz" (and its ".tgz" alias) for POSIX and
 // ".zip" for Windows. Separators between project/os/arch may be underscores
-// or hyphens; a middle version segment is tolerated but not required.
+// or hyphens; a middle version segment is tolerated but not required, and
+// may itself span multiple tokens because SemVer prerelease identifiers
+// contribute hyphens ("0.2.0-rc.1", "0.2.0-beta.2", etc.). We therefore
+// anchor on the trailing two tokens as (goos, goarch) rather than counting
+// the whole sequence.
 func assetNameMatches(name, goos, goarch string) bool {
 	ext := assetExt(name)
 	if ext == "" {
@@ -74,25 +78,22 @@ func assetNameMatches(name, goos, goarch string) bool {
 	}
 	stem := strings.TrimSuffix(name, ext)
 
-	// Project prefix: "nistru", followed by either "_" or "-".
 	const project = "nistru"
 	if !strings.HasPrefix(stem, project+"_") && !strings.HasPrefix(stem, project+"-") {
 		return false
 	}
 	rest := stem[len(project)+1:]
 
-	// Split on either separator; the resulting tokens must contain both
-	// goos and goarch as adjacent tokens, in order. We accept one leading
-	// version token (e.g. "v0.2.0" or "0.2.0") or none.
+	// The version segment is optional and may itself contain hyphens when
+	// a SemVer prerelease identifier is present ("0.2.0-rc.1", "0.2.0-beta.2",
+	// etc.), producing extra tokens between the project prefix and the
+	// trailing (goos, goarch) pair. Anchor on the last two tokens rather
+	// than counting the whole sequence.
 	tokens := splitOnSepChars(rest, "_-")
-	switch len(tokens) {
-	case 2:
-		return tokens[0] == goos && tokens[1] == goarch
-	case 3:
-		return tokens[1] == goos && tokens[2] == goarch
-	default:
+	if len(tokens) < 2 {
 		return false
 	}
+	return tokens[len(tokens)-2] == goos && tokens[len(tokens)-1] == goarch
 }
 
 // assetExt returns the archive extension (".tar.gz", ".tgz", ".zip") of

--- a/internal/plugins/autoupdate/asset_test.go
+++ b/internal/plugins/autoupdate/asset_test.go
@@ -141,3 +141,91 @@ func TestAssetMatchIgnoresUnrelatedEntries(t *testing.T) {
 		t.Fatalf("err = %v, want ErrNoAssetForPlatform", err)
 	}
 }
+
+// TestAssetNameMatchesTable exercises assetNameMatches across positive and
+// negative cases, with special focus on SemVer prerelease versions produced
+// by goreleaser (e.g. v0.2.0-rc.1). The parser must anchor on the trailing
+// (goos, goarch) pair because a hyphenated version segment contributes extra
+// tokens.
+func TestAssetNameMatchesTable(t *testing.T) {
+	cases := []struct {
+		name   string
+		goos   string
+		goarch string
+		want   bool
+	}{
+		// Prerelease positives for the 5 shipped platforms.
+		{"nistru_0.2.0-rc.1_linux_amd64.tar.gz", "linux", "amd64", true},
+		{"nistru_0.2.0-rc.1_linux_arm64.tar.gz", "linux", "arm64", true},
+		{"nistru_0.2.0-rc.1_darwin_amd64.tar.gz", "darwin", "amd64", true},
+		{"nistru_0.2.0-rc.1_darwin_arm64.tar.gz", "darwin", "arm64", true},
+		{"nistru_0.2.0-rc.1_windows_amd64.zip", "windows", "amd64", true},
+
+		// Other prerelease shapes.
+		{"nistru_0.2.0-beta.2_linux_amd64.tar.gz", "linux", "amd64", true},
+		{"nistru_0.2.0-alpha_darwin_arm64.tar.gz", "darwin", "arm64", true},
+		// SemVer build metadata: '+' is not a separator, so the whole
+		// "rc.1+build.42" survives as a single token, leaving the trailing
+		// (goos, goarch) pair intact.
+		{"nistru_0.2.0-rc.1+build.42_linux_amd64.tar.gz", "linux", "amd64", true},
+
+		// Legacy positives that must keep working.
+		{"nistru_0.2.0_linux_amd64.tar.gz", "linux", "amd64", true},
+		{"nistru_linux_amd64.tar.gz", "linux", "amd64", true},
+		{"nistru-linux-amd64.tar.gz", "linux", "amd64", true},
+
+		// Negatives: wrong os/arch, wrong prefix, unknown extension.
+		{"nistru_0.2.0-rc.1_linux_amd64.tar.gz", "darwin", "amd64", false},
+		{"nistru_0.2.0-rc.1_darwin_amd64.tar.gz", "darwin", "arm64", false},
+		{"hello_0.2.0_linux_amd64.tar.gz", "linux", "amd64", false},
+		{"nistru_0.2.0-rc.1_linux_amd64.unknown", "linux", "amd64", false},
+	}
+	for _, tc := range cases {
+		got := assetNameMatches(tc.name, tc.goos, tc.goarch)
+		if got != tc.want {
+			t.Errorf("assetNameMatches(%q, %q, %q) = %v, want %v",
+				tc.name, tc.goos, tc.goarch, got, tc.want)
+		}
+	}
+}
+
+// TestAssetMatch_PrereleaseV020RC1 mirrors the real v0.2.0-rc.1 release
+// artifact set (https://github.com/savimcio/nistru/releases/tag/v0.2.0-rc.1)
+// to guard against the hyphenated-version regression that was caught during
+// the initial release-pipeline smoke test.
+func TestAssetMatch_PrereleaseV020RC1(t *testing.T) {
+	rel := Release{Assets: mkAssets(
+		"nistru_0.2.0-rc.1_linux_amd64.tar.gz",
+		"nistru_0.2.0-rc.1_linux_arm64.tar.gz",
+		"nistru_0.2.0-rc.1_darwin_amd64.tar.gz",
+		"nistru_0.2.0-rc.1_darwin_arm64.tar.gz",
+		"nistru_0.2.0-rc.1_windows_amd64.zip",
+		"checksums.txt",
+	)}
+
+	platforms := []struct {
+		goos    string
+		goarch  string
+		wantBin string
+	}{
+		{"linux", "amd64", "nistru_0.2.0-rc.1_linux_amd64.tar.gz"},
+		{"linux", "arm64", "nistru_0.2.0-rc.1_linux_arm64.tar.gz"},
+		{"darwin", "amd64", "nistru_0.2.0-rc.1_darwin_amd64.tar.gz"},
+		{"darwin", "arm64", "nistru_0.2.0-rc.1_darwin_arm64.tar.gz"},
+		{"windows", "amd64", "nistru_0.2.0-rc.1_windows_amd64.zip"},
+	}
+	for _, p := range platforms {
+		bin, cs, err := AssetMatch(rel, p.goos, p.goarch)
+		if err != nil {
+			t.Fatalf("AssetMatch(%s/%s): unexpected err=%v", p.goos, p.goarch, err)
+		}
+		if bin.Name != p.wantBin {
+			t.Errorf("AssetMatch(%s/%s) binary = %q, want %q",
+				p.goos, p.goarch, bin.Name, p.wantBin)
+		}
+		if cs.Name != "checksums.txt" {
+			t.Errorf("AssetMatch(%s/%s) checksums = %q, want checksums.txt",
+				p.goos, p.goarch, cs.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- The auto-update plugin's archive-name parser rejected every SemVer prerelease asset, silently forcing the dev channel to `go install` fallback.
- Caught during the first smoke test of the release pipeline against https://github.com/savimcio/nistru/releases/tag/v0.2.0-rc.1.
- Fix: anchor on the trailing `(goos, goarch)` tokens instead of counting tokens, so hyphenated version segments (`0.2.0-rc.1`, `0.2.0-beta.2`, etc.) pass through.

## Test plan

- [x] New `asset_test.go` cases cover all 5 shipped platforms with `v0.2.0-rc.1`, plus `-beta.2`, `-alpha`, and `+build.42` metadata
- [x] Preserved negatives (wrong os/arch, wrong project prefix, unknown extension)
- [x] New `TestAssetMatch_PrereleaseV020RC1` proves end-to-end resolution against a `Release` struct that mirrors the published artifacts
- [x] `make ci` green
- [ ] CI green on this PR
- [ ] After merge: re-run the e2e cross-check against the published `v0.2.0-rc.1` release — expect all 5 platforms to resolve cleanly

## Not changed

Release artifacts themselves are correct — this is purely the client-side parser.