### PR TITLE
docs: install options, v0.2.0 changelog, release guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.2.0] — 2026-04-21
+
 ### Added
 
 - First-party `autoupdate` plugin: watches GitHub Releases for new versions, shows an update-available badge in the status bar, and ships palette commands to install, roll back, switch channel (release/dev), check now, and view release notes.
 - Plugin host primitives for in-process async notifications: `plugin.HostAware` interface and `Host.PostNotif(plugin, method, params)` non-blocking notification pump.
+- Layered TOML settings (`~/.config/nistru/config.toml` + `<root>/.nistru/config.toml` + `NISTRU_*` env overrides) threaded into the editor and plugins, with palette commands to open, reload, and dump the resolved config.
 - `nistru -version` flag that prints the running version.
 - Makefile `build` target with `-ldflags -X main.Version=$(git describe ...)` for reproducible version embedding.
+- GoReleaser release pipeline: cross-compiled archives (linux/darwin/windows × amd64/arm64, minus windows/arm64), a `checksums.txt` (SHA-256) manifest, Debian and RPM packages via nfpm, and a Homebrew formula published to [`savimcio/homebrew-tap`](https://github.com/savimcio/homebrew-tap) for stable tags.
+- `release-check` and `release-snapshot` Makefile targets for local goreleaser config-lint and full dry-run builds into `dist/`.
 
 ### Changed
 
 - Reorganize repo to modern Go layout: editor core moves to `internal/editor/`, binary entry point to `cmd/nistru/`, first-party plugins to `internal/plugins/`. Public packages (`plugin/`, `sdk/plugsdk/`) unchanged.
+
+### Fixed
+
+- `internal/plugins/autoupdate` asset-name matcher now accepts SemVer prerelease versions (`v0.2.0-rc.1` etc.). Previously the dev channel silently fell back to `go install` because prerelease asset names did not match the release-only regex.
 
 ### Security
 
@@ -25,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 - **`go install github.com/savimcio/nistru@latest` no longer works; install via `go install github.com/savimcio/nistru/cmd/nistru@latest` instead.**
+
+## [0.2.0-rc.1] — 2026-04-21
+
+Initial prerelease cut to smoke-test the goreleaser pipeline and the `autoupdate` plugin's dev-channel resolution.
 
 ## [0.1.0] — 2026-04-21
 
@@ -58,4 +73,6 @@ Initial public release.
 - `README.md`, `docs/testing.md`, `docs/plugins.md`, and a project-level `CLAUDE.md` with a "when modifying X, update Y" rule table.
 - `LICENSE` (MIT), `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `SECURITY.md`, GitHub issue forms, pull-request template, Dependabot config, `.editorconfig`.
 
+[0.2.0]: https://github.com/savimcio/nistru/releases/tag/v0.2.0
+[0.2.0-rc.1]: https://github.com/savimcio/nistru/releases/tag/v0.2.0-rc.1
 [0.1.0]: https://github.com/savimcio/nistru/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,34 @@ One logical change per commit. If you've stacked work, split it — smaller PRs 
 - Package doc comments (`// Package foo ...`) on every exported package.
 - Write no comments unless the *why* is non-obvious. Don't narrate what the code already says.
 
+## Releasing
+
+Maintainer-facing. Releases are tag-triggered: pushing any `v*` tag fires the GoReleaser workflow, which cross-builds archives, packages, and the Homebrew formula.
+
+**Cutting a release.** From a merged-to-master commit:
+
+```sh
+git checkout master
+git pull origin master
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Do **not** push `v*` tags from feature branches. The workflow triggers on any `v*` tag push regardless of SHA and will happily release from wherever you pointed the tag.
+
+**Prereleases.** Tags with a SemVer prerelease identifier (`vX.Y.Z-rc.1`, `vX.Y.Z-beta.2`, etc.) are detected by `release.prerelease: auto` in `.goreleaser.yaml` and published with `prerelease: true` on GitHub. That flag is what feeds the `autoupdate` plugin's `dev` channel.
+
+**Homebrew tap.** Stable tags (no prerelease identifier) publish `Formula/nistru.rb` to [`savimcio/homebrew-tap`](https://github.com/savimcio/homebrew-tap) using the `HOMEBREW_TAP_TOKEN` secret — a fine-grained PAT scoped to that tap, stored as a repo secret on `savimcio/nistru`. Prereleases skip the tap via `brews.skip_upload: auto`.
+
+**Local validation before tagging.**
+
+| Command | Effect |
+|---|---|
+| `make release-check` | lints the goreleaser config without building |
+| `make release-snapshot` | full dry-run build into `dist/`; produces every artifact the real pipeline would |
+
+Run both before pushing a tag. A snapshot that fails locally will fail in CI.
+
 ## Bug reports and features
 
 Use the GitHub issue forms. The bug form asks for the Nistru commit, Go version, OS, and terminal — fill them in; those four answers unblock most triage.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,36 @@ A minimal terminal text editor with a file-tree sidebar, modal vim-style editing
 
 ## Install
 
+### Homebrew (macOS + Linux)
+
+```sh
+brew install savimcio/homebrew-tap/nistru
+```
+
+The formula tracks stable releases; `brew upgrade nistru` picks up new versions.
+
+### Pre-built binaries
+
+Archives for linux/darwin/windows × amd64/arm64 are published on the [Releases page](https://github.com/savimcio/nistru/releases) (windows/arm64 excepted). Each release ships a `checksums.txt` (SHA-256) alongside the archives.
+
+### Debian / RPM
+
+```sh
+# Debian / Ubuntu (pick the arch matching your system)
+curl -LO https://github.com/savimcio/nistru/releases/latest/download/nistru_<version>_linux_amd64.deb
+sudo dpkg -i nistru_<version>_linux_amd64.deb
+
+# Fedora / RHEL
+sudo rpm -i https://github.com/savimcio/nistru/releases/download/v<version>/nistru_<version>_linux_amd64.rpm
+```
+
+### From source
+
 ```sh
 go install github.com/savimcio/nistru/cmd/nistru@latest
 ```
 
-Or build from source:
+Or build a checkout:
 
 ```sh
 git clone https://github.com/savimcio/nistru.git
@@ -140,6 +165,8 @@ Four palette commands (`Ctrl+P`) manage settings:
 ## Auto-update
 
 Nistru ships with a first-party `autoupdate` plugin that watches GitHub Releases for newer versions. It is enabled by default, runs quietly in the background, and never swaps the binary without explicit palette invocation.
+
+**Installed via a package manager?** If you installed through Homebrew, `.deb`, or `.rpm`, update through that channel instead — the built-in updater targets the single-binary install path (`go install` or a direct archive download).
 
 **What it does.** Once an hour, the plugin issues a single unauthenticated `GET` to `api.github.com/repos/savimcio/nistru/releases`. If a newer version is available, a status-bar segment announces it; palette commands let you install it, roll back, switch channels, or view release notes. No telemetry is collected and no data is sent outbound beyond the GitHub API request itself.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -470,6 +470,19 @@ The real `autoupdate` plugin (`internal/plugins/autoupdate/`) fleshes this shape
 
 Use `PostNotif` only from in-process plugins. Out-of-process plugins already have a dedicated writer goroutine and should emit notifications via `plugsdk.Client` instead.
 
+### Release channels and asset layout
+
+The `autoupdate` plugin exposes two channels, selected per-user:
+
+| Channel | Tracks |
+|---|---|
+| `release` (default) | GitHub releases with `prerelease: false` |
+| `dev` | the newest release overall, including ones flagged `prerelease: true` |
+
+Channel selection layers (low → high): defaults → `[plugins.autoupdate] channel = "dev"` in the layered TOML config → `NISTRU_AUTOUPDATE_CHANNEL=dev` env var → the `autoupdate:switch-channel` palette command (which persists into the plugin's state file).
+
+Asset discovery on a release follows the GoReleaser default template: the plugin looks for `nistru_<version>_<os>_<arch>.tar.gz` (or `.zip` on Windows) and requires a sibling `checksums.txt` SHA-256 manifest on the same release. **It refuses to install without `checksums.txt`**; no manifest means no binary swap, and the plugin falls back to notifying with the `go install` command instead.
+
 ## Reference
 
 - Host internals: `plugin/host.go`, `plugin/extproc.go`


### PR DESCRIPTION
## Summary

- **README install section** reworked to present Homebrew (`brew install savimcio/homebrew-tap/nistru`), GitHub release downloads, `.deb`/`.rpm`, and `go install` in order of ease. Clarifies that package-manager installs update via their package manager, not the built-in auto-updater.
- **CHANGELOG** moves `[Unreleased]` content into a dated `[0.2.0] — 2026-04-21` section, adds a `[0.2.0-rc.1]` sibling, and fills in missing entries for the goreleaser pipeline and the AssetMatch prerelease fix (#11).
- **docs/plugins.md** adds a short appendix on the auto-update plugin's release/dev channels, the goreleaser archive template it parses, and the mandatory `checksums.txt`.
- **CONTRIBUTING** adds a maintainer-facing "Releasing" section covering tag-triggered flow, prerelease auto-detection, the Homebrew tap token, and the local `release-check` / `release-snapshot` dry-run targets.

## Test plan

- [x] `make lint` passes
- [x] No source / config / workflow changes — pure docs
- [ ] CI green on this PR
- [ ] Spot-read the rendered CHANGELOG + README on the PR's Files tab to confirm formatting