### PR TITLE
ci(release): refuse to release when tag SHA is not on master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,15 @@ jobs:
           go-version: '1.26.x'
           cache: true
 
+      - name: Verify tag is on master
+        run: |
+          git fetch origin master --depth=100
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/master; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA}, which is not on master. Refusing to release."
+            exit 1
+          fi
+          echo "Tag ${GITHUB_REF_NAME} → ${GITHUB_SHA} is an ancestor of origin/master; proceeding."
+
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v7
         with:


### PR DESCRIPTION
## Summary

- The release workflow triggers on any `v*` tag push regardless of which commit the tag points at. Accidentally tagging a feature-branch SHA (or, in the worst case, a compromised collaborator doing so intentionally) would publish a release built from unreviewed code.
- This adds a `Verify tag is on master` step that runs `git merge-base --is-ancestor` against `origin/master` and fails the job early if the tag isn't reachable.

## Scope

This is the workflow-side guard only. GitHub-side protections (tag rulesets, signed tags, Environment approval) are out-of-band knobs and not changed here.

## Test plan

- [x] `make lint` green
- [ ] CI green on this PR (`.github/workflows/ci.yml` is unchanged, so only the `test` job runs)
- [ ] After merge + next real release tag (`v0.2.1` or later), the verify step logs "Tag … is an ancestor of origin/master; proceeding."
- [ ] Manual "sad path" spot-check could be done by pushing a `vtest-*` tag on a throwaway branch SHA — but that would require a workflow-file change to key the trigger on `vtest-*` too, so we're relying on the code review here instead.