### PR TITLE
docs(readme): use short-form "savimcio/tap" for brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ A minimal terminal text editor with a file-tree sidebar, modal vim-style editing
 ### Homebrew (macOS + Linux)
 
 ```sh
-brew install savimcio/homebrew-tap/nistru
+brew install savimcio/tap/nistru
 ```
+
+The tap repo is [`savimcio/homebrew-tap`](https://github.com/savimcio/homebrew-tap); Homebrew strips the `homebrew-` prefix, so `savimcio/tap` is the short form used with `brew`.
 
 The formula tracks stable releases; `brew upgrade nistru` picks up new versions.
 


### PR DESCRIPTION
## Summary

Homebrew treats a tap repo named `homebrew-<short>` as addressable by `<owner>/<short>`. Our tap repo is `savimcio/homebrew-tap`, so users can say `brew install savimcio/tap/nistru` instead of `brew install savimcio/homebrew-tap/nistru`. README updated; repo references elsewhere (CHANGELOG / CONTRIBUTING linking to github.com/savimcio/homebrew-tap) stay as-is because they point at the actual repo.

## Test plan

- [x] `git grep savimcio/homebrew-tap/nistru` shows no hits after the change
- [x] `make lint` green
- [ ] CI green
- [ ] After merge: `brew tap savimcio/tap && brew install nistru` resolves against the published formula